### PR TITLE
fix(ci): drop backend-tests from needs: (orphan reference from #22)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
     name: Build Check
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [backend-tests, frontend-tests]
+    needs: [frontend-tests]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -116,7 +116,7 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [backend-tests, frontend-tests]
+    needs: [frontend-tests]
 
     services:
       postgres:


### PR DESCRIPTION
PR #22 deleted the backend-tests job but left two downstream jobs still requiring it via `needs: [backend-tests, frontend-tests]`. GitHub Actions refused to run the workflow (job referenced in needs: doesn't exist → validation error, run reported 0 jobs / immediate failure).

Drops the orphan reference. Downstream jobs (build, e2e-tests) now gate on frontend-tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)