### PR TITLE
ci(e2e): migrate + seed DB before Playwright runs (RA-1164)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,19 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
 
+      # RA-1164 — the ephemeral postgres service starts empty; E2E tests
+      # depend on migrated schema + seeded course catalog. Apply both
+      # before the Playwright run or every test hits an empty DB.
+      - name: Apply Prisma migrations
+        run: npm run prisma:migrate
+        env:
+          DATABASE_URL: postgresql://starter_user:local_dev_password@localhost:5432/starter_db
+
+      - name: Seed course catalog
+        run: npm run db:seed-courses
+        env:
+          DATABASE_URL: postgresql://starter_user:local_dev_password@localhost:5432/starter_db
+
       - name: Run E2E tests
         run: npm run test:e2e
         env:


### PR DESCRIPTION
## Why

[RA-1164](https://linear.app/unite-group/issue/RA-1164) — CARSI CI: 4/5 jobs passing, E2E Tests fail because the ephemeral `postgres:15-alpine` service starts empty and Playwright tests depend on migrated schema + seeded course catalog.

## Fix

Add two steps between Playwright browser install and the test run in [`.github/workflows/ci.yml`](.github/workflows/ci.yml):

```yaml
- name: Apply Prisma migrations
  run: npm run prisma:migrate
  env:
    DATABASE_URL: postgresql://starter_user:local_dev_password@localhost:5432/starter_db

- name: Seed course catalog
  run: npm run db:seed-courses
  env:
    DATABASE_URL: postgresql://starter_user:local_dev_password@localhost:5432/starter_db
```

Both scripts already exist in `package.json` (`prisma:migrate`, `db:seed-courses`) and run in <15s on local — well within the job's 30-min timeout.

## Blast radius

- Workflow-only change. No test code changes.
- Affects only the E2E Tests job — other 4 jobs unchanged.
- Idempotent: Prisma migrate-deploy is safe on a re-run; course seed is additive and keyed on slug.

## Test plan
- [ ] Merge → watch CI → expect 5/5 jobs green for the first time
- [ ] If E2E still fails, the failure will now be in Playwright itself (real test assertion), not the DB setup

## Closes
- [RA-1164](https://linear.app/unite-group/issue/RA-1164)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved E2E test infrastructure by automating database schema migration and initial data seeding prior to test execution, enhancing test reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->