### PR TITLE
fix(security): GP-366+367 remove hardcoded secrets + env-var refactor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,3 +136,9 @@ ADMIN_PASSWORD=change-me
 # ADMIN_PANEL_EMAILS=support@example.com
 # Optional: same email shown on the admin login form in the browser (NEXT_PUBLIC_* is bundled for the client).
 # NEXT_PUBLIC_ADMIN_EMAIL=you@example.com
+
+# Password required to unlock CCW (Contamination Control Workshop) participant
+# training resources via POST /api/ccw-training/verify. Set to the training
+# cohort's shared passphrase (rotate per cohort). Server-only — do NOT prefix
+# with NEXT_PUBLIC_.
+CCW_TRAINING_PASSWORD=replace-me

--- a/src/components/lms/CourseCard.tsx
+++ b/src/components/lms/CourseCard.tsx
@@ -35,7 +35,7 @@ interface CourseCardProps {
 // GP-335 PR 1/4: accent now resolved via --discipline-* tokens.
 // The legacy glow/grad values (never currently rendered) are removed in this
 // migration; they'll come back as first-class tokens in PR 4/4 (border + glow).
-const DEFAULT_ACCENT_TOKEN = 'hsl(var(--discipline-water-500))';
+const DEFAULT_ACCENT_TOKEN = 'hsl(var(--discipline-water-500))'; // pragma: allowlist secret
 
 function formatRelativeDate(dateStr: string | null | undefined): string {
   if (!dateStr) return '';

--- a/src/lib/server/ccw-unlock.ts
+++ b/src/lib/server/ccw-unlock.ts
@@ -1,8 +1,14 @@
 import { createHash, timingSafeEqual } from 'node:crypto';
 
-const EXPECTED_PASSWORD = 'CCW-TRAINING';
+/**
+ * Password required to unlock CCW participant training resources.
+ * Sourced from `CCW_TRAINING_PASSWORD` env var; see `.env.example`.
+ * Falls back to an empty string so verification fails closed if unset.
+ */
+const EXPECTED_PASSWORD = process.env.CCW_TRAINING_PASSWORD ?? '';
 
 export function verifyCcwPassword(attempt: string): boolean {
+  if (!EXPECTED_PASSWORD) return false;
   const a = createHash('sha256').update(attempt, 'utf8').digest();
   const b = createHash('sha256').update(EXPECTED_PASSWORD, 'utf8').digest();
   return a.length === b.length && timingSafeEqual(a, b);


### PR DESCRIPTION
## Summary
- **GP-366** (`src/components/lms/CourseCard.tsx:38`): False positive — the scanner matched the identifier `DEFAULT_ACCENT_TOKEN`, which holds a CSS value (`hsl(var(--discipline-water-500))`), not a secret. Annotated with `// pragma: allowlist secret` to suppress the detector.
- **GP-367** (`src/lib/server/ccw-unlock.ts:3`): Hardcoded CCW training-resource unlock password moved behind `process.env.CCW_TRAINING_PASSWORD`. `verifyCcwPassword` now fails closed when the env var is unset. Documented in `.env.example`.

## Rotation required (user action)
The previous CCW password is in git history. After merge:
1. Set `CCW_TRAINING_PASSWORD` in Vercel (all envs) to a fresh value.
2. Update 1Password CCW training entry.
3. Distribute the new value to the current CCW cohort.

## Test plan
- [x] `npx tsc --noEmit` — no new errors introduced (baseline: 43 pre-existing errors in `public-courses-list.ts`, still 43 after).
- [x] Empty env var → `verifyCcwPassword` returns `false` (fail-closed).
- [ ] After merge: verify `/api/ccw-training/verify` rejects old password, accepts new one.

Closes GP-366, GP-367.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>