### PR TITLE
fix(security): rate-limit + Turnstile on /api/contact + /api/submit (RA-3022)

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,20 +1,67 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
+import { applyRateLimit, UNKNOWN_IP } from '@/lib/rate-limit';
+import { verifyTurnstile } from '@/lib/turnstile';
+
 interface ContactPayload {
   firstName: string;
   lastName: string;
   email: string;
   message: string;
+  cfTurnstileResponse?: string;
+}
+
+// RA-3022 — rate limit + Cloudflare Turnstile on anonymous PII intake.
+// 5 submissions per hour per IP (defense-in-depth alongside Turnstile +
+// Cloudflare WAF). One hour = 3_600_000 ms.
+const LIMIT = 5;
+const WINDOW_MS = 60 * 60 * 1000;
+
+function getClientIp(req: NextRequest): string {
+  return (
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    req.headers.get('x-real-ip') ??
+    UNKNOWN_IP
+  );
 }
 
 export async function POST(req: NextRequest) {
   try {
+    // 1. Rate limit BEFORE parsing body so abusers cost less per request.
+    const ip = getClientIp(req);
+    const rl = applyRateLimit(ip, LIMIT, WINDOW_MS);
+    if (!rl.ok) {
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again later.' },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': String(Math.ceil((rl.resetAt - Date.now()) / 1000)),
+          },
+        },
+      );
+    }
+
     const body = (await req.json()) as ContactPayload;
 
-    // Basic validation
+    // 2. Basic validation
     if (!body.firstName || !body.lastName || !body.email || !body.message) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    // 3. Turnstile CAPTCHA — required.
+    const tsToken =
+      body.cfTurnstileResponse ?? req.headers.get('cf-turnstile-response');
+    if (!tsToken) {
+      return NextResponse.json({ error: 'CAPTCHA required.' }, { status: 400 });
+    }
+    const ts = await verifyTurnstile(tsToken, ip === UNKNOWN_IP ? null : ip);
+    if (!ts.success) {
+      return NextResponse.json(
+        { error: 'CAPTCHA verification failed.' },
+        { status: 401 },
+      );
     }
 
     // Persist or forward contact submissions here (e.g. email provider, CRM) when configured.

--- a/app/api/submit/route.ts
+++ b/app/api/submit/route.ts
@@ -1,6 +1,14 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
+import { applyRateLimit, UNKNOWN_IP } from '@/lib/rate-limit';
+import { verifyTurnstile } from '@/lib/turnstile';
+
+/* ─── RA-3022 — rate-limit + Turnstile config ─────────────────────────────── */
+
+const LIMIT = 5;
+const WINDOW_MS = 60 * 60 * 1000; // 5/hour per IP
+
 /* ─── Types ───────────────────────────────────────────────────────────────── */
 
 const VALID_TYPES = [
@@ -27,6 +35,7 @@ interface SubmissionPayload {
   submission_description?: string;
   terms_accepted: boolean;
   guidelines_accepted: boolean;
+  cfTurnstileResponse?: string;
 }
 
 interface HubSubmissionInsert {
@@ -67,15 +76,50 @@ function getClientIp(req: NextRequest): string | null {
   );
 }
 
+function getClientIpForLimit(req: NextRequest): string {
+  return getClientIp(req) ?? UNKNOWN_IP;
+}
+
 /* ─── Route handler ───────────────────────────────────────────────────────── */
 
 export async function POST(req: NextRequest) {
+  /* RA-3022 — 1. Rate limit BEFORE parsing body so abusers cost less per request. */
+  const ip = getClientIpForLimit(req);
+  const rl = applyRateLimit(ip, LIMIT, WINDOW_MS);
+  if (!rl.ok) {
+    return NextResponse.json(
+      { success: false, error: 'Too many requests. Please try again later.' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(Math.ceil((rl.resetAt - Date.now()) / 1000)),
+        },
+      },
+    );
+  }
+
   /* 1. Parse body */
   let body: SubmissionPayload;
   try {
     body = (await req.json()) as SubmissionPayload;
   } catch {
     return NextResponse.json({ success: false, error: 'Invalid request body.' }, { status: 400 });
+  }
+
+  /* RA-3022 — Turnstile CAPTCHA — required for unauthenticated PII intake. */
+  const tsToken = body.cfTurnstileResponse ?? req.headers.get('cf-turnstile-response');
+  if (!tsToken) {
+    return NextResponse.json(
+      { success: false, error: 'CAPTCHA required.' },
+      { status: 400 },
+    );
+  }
+  const ts = await verifyTurnstile(tsToken, ip === UNKNOWN_IP ? null : ip);
+  if (!ts.success) {
+    return NextResponse.json(
+      { success: false, error: 'CAPTCHA verification failed.' },
+      { status: 401 },
+    );
   }
 
   /* 2. Validate required fields */
@@ -147,14 +191,20 @@ export async function POST(req: NextRequest) {
     user_agent: req.headers.get('user-agent'),
   };
 
-  /* 4. Forward to FastAPI hub intake */
+  /* 4. Forward to FastAPI hub intake — RA-3022 adds X-Internal-Auth so the
+        FastAPI side can reject anything that didn't go through this gate. */
+  const intakeSecret = process.env.HUB_INTAKE_SECRET;
+  const forwardHeaders: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  };
+  if (intakeSecret?.trim()) {
+    forwardHeaders['X-Internal-Auth'] = intakeSecret;
+  }
   try {
     const res = await fetch(`${apiUrl.replace(/\/$/, '')}/api/hub/submissions/intake`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
+      headers: forwardHeaders,
       body: JSON.stringify(record),
     });
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,70 @@
+// src/lib/rate-limit.ts — RA-3022.
+//
+// In-process token-bucket rate limiter. Defense-in-depth alongside
+// Cloudflare Turnstile + WAF — Turnstile is the strong signal, this is
+// the cheap second gate (no Cloudflare round-trip needed for the limit
+// check itself).
+//
+// Limitation: stateless serverless functions reset memory per cold
+// start, so the window is best-effort across invocations on the same
+// worker. For globally consistent quotas, migrate to Vercel KV /
+// Upstash Redis (`@upstash/ratelimit`) — left as a follow-up since
+// adding a dep + provisioning Redis is a separate workstream.
+//
+// In practice, Cloudflare Turnstile + an instance-local memory window
+// blocks the abuse class this fix targets (anonymous bots filling the
+// hub_submissions table). A determined attacker who fans out across
+// cold starts still gets stopped at Turnstile.
+
+interface Window {
+  count: number;
+  resetAt: number;
+}
+
+const STORE = new Map<string, Window>();
+
+// Cap the map at 10k entries so a flood of unique IPs can't OOM the
+// worker. LRU-style eviction is not needed — we just clear the map
+// when it crosses the threshold. Loses some active windows but keeps
+// memory bounded.
+const MAX_KEYS = 10_000;
+
+export interface RateLimitResult {
+  ok: boolean;
+  remaining: number;
+  resetAt: number;
+}
+
+export function applyRateLimit(
+  ip: string,
+  limit: number,
+  windowMs: number,
+): RateLimitResult {
+  const now = Date.now();
+
+  if (STORE.size > MAX_KEYS) {
+    STORE.clear();
+  }
+
+  const existing = STORE.get(ip);
+  if (!existing || existing.resetAt <= now) {
+    const fresh: Window = { count: 1, resetAt: now + windowMs };
+    STORE.set(ip, fresh);
+    return { ok: true, remaining: limit - 1, resetAt: fresh.resetAt };
+  }
+
+  existing.count += 1;
+  if (existing.count > limit) {
+    return { ok: false, remaining: 0, resetAt: existing.resetAt };
+  }
+  return {
+    ok: true,
+    remaining: limit - existing.count,
+    resetAt: existing.resetAt,
+  };
+}
+
+// Sentinel used by routes when client IP cannot be determined — keys
+// every "no-IP" caller into the same bucket so they can't bypass the
+// limit by spoofing missing headers.
+export const UNKNOWN_IP = "__unknown__";

--- a/src/lib/turnstile.ts
+++ b/src/lib/turnstile.ts
@@ -1,0 +1,74 @@
+// src/lib/turnstile.ts — RA-3022.
+//
+// Server-side verification of Cloudflare Turnstile tokens.
+// Required for any unauthenticated public POST endpoint that accepts
+// PII or causes server-side work.
+//
+// Caller contract:
+//   1. Frontend renders <Turnstile> widget; user solves; widget posts a
+//      token via the form payload (`cf-turnstile-response` field).
+//   2. This module's `verifyTurnstile()` POSTs the token + remoteIP to
+//      Cloudflare's siteverify endpoint and returns true iff valid.
+//   3. `TURNSTILE_SECRET_KEY` must be set. If missing → returns false +
+//      logs a warning (fails closed — the route should already 503).
+//
+// Docs: https://developers.cloudflare.com/turnstile/get-started/server-side-validation/
+
+const SITEVERIFY_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+interface TurnstileVerifyResponse {
+  success: boolean;
+  "error-codes"?: string[];
+  challenge_ts?: string;
+  hostname?: string;
+  action?: string;
+  cdata?: string;
+}
+
+export async function verifyTurnstile(
+  token: string,
+  remoteIp: string | null,
+): Promise<{ success: boolean; reason?: string }> {
+  if (!token) {
+    return { success: false, reason: "missing_token" };
+  }
+
+  const secret = process.env.TURNSTILE_SECRET_KEY;
+  if (!secret?.trim()) {
+    console.warn(
+      "[turnstile] TURNSTILE_SECRET_KEY not set — failing closed",
+    );
+    return { success: false, reason: "not_configured" };
+  }
+
+  const formData = new URLSearchParams();
+  formData.append("secret", secret);
+  formData.append("response", token);
+  if (remoteIp) {
+    formData.append("remoteip", remoteIp);
+  }
+
+  try {
+    const res = await fetch(SITEVERIFY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formData.toString(),
+      signal: AbortSignal.timeout(5_000),
+    });
+
+    if (!res.ok) {
+      return { success: false, reason: `siteverify_http_${res.status}` };
+    }
+
+    const data = (await res.json()) as TurnstileVerifyResponse;
+    if (data.success) return { success: true };
+    return {
+      success: false,
+      reason: (data["error-codes"] ?? []).join(",") || "siteverify_rejected",
+    };
+  } catch (err) {
+    console.warn("[turnstile] siteverify request failed:", err);
+    return { success: false, reason: "siteverify_unreachable" };
+  }
+}


### PR DESCRIPTION
## Summary
Adds two security gates BEFORE body parse on both anonymous PII intake routes:

1. **Rate limit** (5/hour/IP) via new `src/lib/rate-limit.ts` token-bucket helper
2. **Cloudflare Turnstile verification** via new `src/lib/turnstile.ts`

`/api/submit` also gets an `X-Internal-Auth` header on the FastAPI hub-intake forward so the upstream can reject traffic that didn't pass through this gate.

## Why
Both routes were unauthenticated public POST endpoints accepting PII (name, email, phone, company, IP, UA). RA-1286 already established the portfolio policy: *"Public unauthenticated endpoints need CAPTCHA, not just IP rate limit."* CARSI never got the treatment. Open to spam-pollution of the hub intake table.

## Local smoke
Rate-limit helper exercised through 7 sequential calls — first 5 allowed, 6+7 blocked, fresh IP starts a clean window. ✓

## Operator follow-ups required
- [ ] Set `TURNSTILE_SECRET_KEY` (Cloudflare dashboard → Turnstile → siteverify secret)
- [ ] Set `HUB_INTAKE_SECRET` (matching value on the FastAPI side)
- [ ] Frontend: wire `<Turnstile>` widget on `/contact` + `/submit` form pages to post `cfTurnstileResponse` in the body
- [ ] FastAPI: gate `/api/hub/submissions/intake` on `X-Internal-Auth == HUB_INTAKE_SECRET`

## Out of scope (separable follow-ups)
- Disposable-email-domain marker + MX-record pre-check (ticket step 4)
- Migration to Vercel KV / `@upstash/ratelimit` for cross-instance quota (in-process is fine alongside Turnstile)

## CI note
The CARSI `Frontend Tests` job currently fails with `eslint.config.(js|mjs|cjs) not found` — see CleanExpo/CARSI#110 (RA-3015), which I just pushed an `eslint.config.mjs` to. Once #110 merges, this PR's lint check will also pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contact and submit forms now require CAPTCHA verification to enhance security and prevent spam.
  * Rate limiting has been added to contact and submit endpoints to protect against abuse and excessive requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CleanExpo/CARSI/pull/112)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->