### PR TITLE
feat(admin): admin_users table + DB-backed login (RA-3027)

### DIFF
--- a/app/api/admin/login/route.ts
+++ b/app/api/admin/login/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { timingSafeEqual } from 'node:crypto';
 
 import {
   ADMIN_COOKIE_NAME,
@@ -6,8 +7,80 @@ import {
   getAdminEmail,
   getAdminPassword,
 } from '@/lib/admin/admin-auth';
+import {
+  adminCount,
+  recordAdminLogin,
+  verifyAdminByEmail,
+} from '@/lib/admin/admin-store';
+import { applyRateLimit, UNKNOWN_IP } from '@/lib/rate-limit';
+
+// RA-3027 — rate-limit admin login (defense-in-depth) + DB-backed lookup.
+//
+// While `admin_users` table is empty, env-var login (legacy single-admin)
+// still works. Once any row exists, env-var login is locked out — the
+// bootstrap script (`pnpm db:admin-bootstrap`) is the documented path
+// to populate the first row.
+//
+// 10 attempts per 15-minute window per IP. Cap chosen above legitimate
+// password-retry rates (3-5 attempts) but well below brute-force rates.
+const LOGIN_LIMIT = 10;
+const LOGIN_WINDOW_MS = 15 * 60 * 1000;
+
+function getClientIp(req: NextRequest): string {
+  return (
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    req.headers.get('x-real-ip') ??
+    UNKNOWN_IP
+  );
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+async function logAdminEvent(event: {
+  outcome: 'success' | 'failure';
+  email: string;
+  ip: string;
+  reason?: string;
+}): Promise<void> {
+  // Best-effort audit log to console. Structured (JSON) so it's
+  // grep-able from log aggregators. Audit table is a separate
+  // follow-up — RA-3027 ticket explicitly splits it out.
+  try {
+    console.log(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        kind: 'admin_login',
+        ...event,
+      }),
+    );
+  } catch {
+    // Swallow logging errors — never block a login attempt on them.
+  }
+}
 
 export async function POST(request: NextRequest) {
+  const ip = getClientIp(request);
+
+  // 1. Rate limit BEFORE body parse so brute-force attempts cost less.
+  const rl = applyRateLimit(`admin:${ip}`, LOGIN_LIMIT, LOGIN_WINDOW_MS);
+  if (!rl.ok) {
+    await logAdminEvent({ outcome: 'failure', email: '', ip, reason: 'rate_limited' });
+    return NextResponse.json(
+      { detail: 'Too many login attempts. Please try again later.' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(Math.ceil((rl.resetAt - Date.now()) / 1000)),
+        },
+      },
+    );
+  }
+
   try {
     const body = (await request.json().catch(() => ({}))) as {
       email?: string;
@@ -18,33 +91,58 @@ export async function POST(request: NextRequest) {
     const password = typeof body.password === 'string' ? body.password.trim() : '';
 
     if (!email || !password) {
+      await logAdminEvent({ outcome: 'failure', email, ip, reason: 'missing_fields' });
       return NextResponse.json({ detail: 'Email and password are required' }, { status: 400 });
     }
 
-    const expectedEmail = getAdminEmail();
-    const expectedPassword = getAdminPassword();
+    // 2. Try the DB-backed table first. If empty, fall back to env-var
+    //    (bootstrap mode — legacy single-admin still works).
+    const count = await adminCount();
 
-    if (
-      email.toLowerCase() !== expectedEmail.toLowerCase() ||
-      password !== expectedPassword
-    ) {
-      return NextResponse.json({ detail: 'Invalid credentials' }, { status: 401 });
+    if (count > 0) {
+      const admin = await verifyAdminByEmail(email, password);
+      if (!admin) {
+        await logAdminEvent({
+          outcome: 'failure', email, ip, reason: 'db_invalid_credentials',
+        });
+        return NextResponse.json({ detail: 'Invalid credentials' }, { status: 401 });
+      }
+      await recordAdminLogin(admin.id, ip === UNKNOWN_IP ? null : ip);
+      const token = await createAdminSessionToken(admin.email);
+      await logAdminEvent({ outcome: 'success', email: admin.email, ip });
+      return setCookieAndReturn(token);
     }
 
+    // Bootstrap mode: env-var single-admin path.
+    const expectedEmail = getAdminEmail();
+    const expectedPassword = getAdminPassword();
+    const emailMatch = email.toLowerCase() === expectedEmail.toLowerCase();
+    const passwordMatch =
+      !!expectedPassword && constantTimeEqual(password, expectedPassword);
+    if (!emailMatch || !passwordMatch) {
+      await logAdminEvent({
+        outcome: 'failure', email, ip, reason: 'env_invalid_credentials',
+      });
+      return NextResponse.json({ detail: 'Invalid credentials' }, { status: 401 });
+    }
     const token = await createAdminSessionToken(email);
-
-    const res = NextResponse.json({ ok: true });
-    res.cookies.set(ADMIN_COOKIE_NAME, token, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      path: '/',
-      maxAge: 60 * 60 * 24, // 1 day
+    await logAdminEvent({
+      outcome: 'success', email, ip, reason: 'env_bootstrap_mode',
     });
-
-    return res;
-  } catch (e) {
+    return setCookieAndReturn(token);
+  } catch (_e) {
     return NextResponse.json({ detail: 'Admin login failed' }, { status: 500 });
   }
 }
 
+function setCookieAndReturn(token: string): NextResponse {
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(ADMIN_COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 60 * 60 * 24, // 1 day
+  });
+  return res;
+}

--- a/app/api/admin/users/search/route.ts
+++ b/app/api/admin/users/search/route.ts
@@ -13,8 +13,24 @@ export async function GET(request: NextRequest) {
   }
 
   const q = request.nextUrl.searchParams.get('q')?.trim() ?? '';
-  if (q.length < 2) {
+  // RA-3027 — bumped from 2 to 3 chars. 2-char substrings return huge
+  // PII slices that resemble enumeration / scraping access patterns.
+  if (q.length < 3) {
     return NextResponse.json({ users: [] });
+  }
+  // RA-3027 — best-effort audit log of admin search queries. Structured
+  // JSON for downstream log aggregation. Failure here is non-fatal.
+  try {
+    console.log(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        kind: 'admin_search',
+        admin_email: session.email,
+        q_length: q.length,
+      }),
+    );
+  } catch {
+    // swallow — never block a search on audit-log failure
   }
 
   const term = q.toLowerCase();

--- a/docs/ADMIN_AUTH_MIGRATION.md
+++ b/docs/ADMIN_AUTH_MIGRATION.md
@@ -1,0 +1,71 @@
+# Admin Auth Migration — RA-3027
+
+This document captures the rollout sequence for the `admin_users` table
+introduced in [RA-3027](https://linear.app/unite-group/issue/RA-3027).
+The migration is **backwards-compatible by design** — the env-var
+single-admin login path stays active until at least one row exists in
+`admin_users`.
+
+## State before this PR
+
+- `ADMIN_EMAIL` + `ADMIN_PASSWORD` env vars define the only admin
+- `app/api/admin/login/route.ts` does plaintext string comparison
+- No rate limit, no audit trail, no per-admin role
+
+## State after this PR (env-var bootstrap mode)
+
+- `admin_users` table exists but is empty
+- Login route tries DB lookup first, sees empty table → falls back to
+  env-var path (with constant-time compare now)
+- Rate limit: 10 attempts / 15 min per IP
+- Structured audit log via `console.log` (JSON lines) on every login
+  success / failure
+
+## State after running `scripts/admin-bootstrap.ts`
+
+- `admin_users` has exactly one row with `ADMIN_EMAIL` + bcrypt-hashed
+  `ADMIN_PASSWORD`
+- Login route detects `admin_users.count() > 0` → env-var path is
+  **locked out** (any login attempt now goes through bcrypt verify
+  against the table)
+- `lastLoginAt` / `lastLoginIp` updated on each successful login
+
+## Rollout sequence (operator)
+
+```bash
+# 1. Apply the migration
+pnpm prisma migrate deploy
+
+# 2. Bootstrap the first admin from the existing env vars
+npx tsx scripts/admin-bootstrap.ts
+
+# 3. Test admin login via the UI (should still work — same creds)
+
+# 4. Optional: add more admins (script not yet written — separate ticket)
+
+# 5. Once happy, remove ADMIN_EMAIL + ADMIN_PASSWORD env vars from prod
+#    (the table is now the source of truth; env vars are inert).
+```
+
+## Rollback
+
+If anything goes wrong after step 2:
+
+```bash
+# Delete the bootstrapped row — falls back to env-var path
+psql $DATABASE_URL -c "DELETE FROM admin_users;"
+```
+
+The migration itself (CREATE TABLE) does not need to be rolled back —
+an empty table is functionally identical to its absence (the login
+route handles both cases).
+
+## Deferred (RA-3027 follow-ups)
+
+The original ticket calls out these as separable follow-ups:
+
+- TOTP MFA on admin login (`otpauth` library)
+- Dedicated `admin_audit_log` table (currently console-logged only)
+- Self-serve password rotation flow
+- Per-admin role enforcement on individual admin endpoints
+- Rotate `ADMIN_JWT_SECRET` after table migration completes

--- a/prisma/migrations/20260512000000_admin_users_table/migration.sql
+++ b/prisma/migrations/20260512000000_admin_users_table/migration.sql
@@ -1,0 +1,28 @@
+-- RA-3027 — Admin users table.
+--
+-- Replaces the single ADMIN_EMAIL+ADMIN_PASSWORD env-var gate for the
+-- CARSI admin surface with a proper Postgres-backed table:
+--   * Multiple admins
+--   * Per-admin bcryptjs password hash (matches the LmsUser pattern)
+--   * Per-admin role for future RBAC
+--   * lastLoginAt + lastLoginIp for audit-trail bootstrapping
+--
+-- Backwards-compatible by design — the env-var login path in
+-- `app/api/admin/login/route.ts` remains active until the table has at
+-- least one row. See `docs/ADMIN_AUTH_MIGRATION.md` for rollout steps.
+
+CREATE TABLE "admin_users" (
+    "id"             UUID         NOT NULL,
+    "email"          TEXT         NOT NULL,
+    "password_hash"  TEXT         NOT NULL,
+    "role"           TEXT         NOT NULL DEFAULT 'admin',
+    "is_active"      BOOLEAN      NOT NULL DEFAULT TRUE,
+    "last_login_at"  TIMESTAMPTZ(6),
+    "last_login_ip"  TEXT,
+    "created_at"     TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"     TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "admin_users_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "admin_users_email_key" ON "admin_users"("email");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -211,3 +211,24 @@ model LmsLearningPathway {
 
   @@map("lms_learning_pathways")
 }
+
+/// RA-3027 — replaces the single ADMIN_EMAIL+ADMIN_PASSWORD env-var gate
+/// for the CARSI admin surface. Multiple admins, per-admin password hash
+/// (bcryptjs), per-admin role, audit-able lastLoginAt.
+///
+/// Migration semantics: backwards-compatible — the env-var login path
+/// remains active until at least one row exists in this table. See
+/// `docs/ADMIN_AUTH_MIGRATION.md` for rollout steps.
+model AdminUser {
+  id             String    @id @default(uuid()) @db.Uuid
+  email          String    @unique
+  passwordHash   String    @map("password_hash")
+  role           String    @default("admin")
+  isActive       Boolean   @default(true) @map("is_active")
+  lastLoginAt    DateTime? @map("last_login_at") @db.Timestamptz(6)
+  lastLoginIp    String?   @map("last_login_ip")
+  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt      DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  @@map("admin_users")
+}

--- a/scripts/admin-bootstrap.ts
+++ b/scripts/admin-bootstrap.ts
@@ -1,0 +1,48 @@
+/**
+ * scripts/admin-bootstrap.ts — RA-3027.
+ *
+ * Copies the current `ADMIN_EMAIL` + `ADMIN_PASSWORD` env vars into the
+ * `admin_users` table as the first row. Idempotent — refuses to run if
+ * the table already has any rows.
+ *
+ * Usage (post-migration deploy):
+ *
+ *   ADMIN_EMAIL=ops@example.com ADMIN_PASSWORD=... npx tsx scripts/admin-bootstrap.ts
+ *
+ * After this script succeeds:
+ *   1. Verify login still works via the admin UI
+ *   2. Rotate ADMIN_PASSWORD via the admin UI (or a future password-reset
+ *      flow) to a NEW value the DB-stored hash anchors to
+ *   3. Remove ADMIN_EMAIL + ADMIN_PASSWORD env vars from production once
+ *      multi-admin onboarding is complete
+ *
+ * The env-var fallback remains active in `app/api/admin/login/route.ts`
+ * only while `admin_users` is empty; this script makes it inert.
+ */
+
+import { bootstrapAdminFromEnv } from '../src/lib/admin/admin-store';
+
+async function main() {
+  console.log('[admin-bootstrap] checking admin_users table...');
+  try {
+    const result = await bootstrapAdminFromEnv();
+    if (!result) {
+      console.error('[admin-bootstrap] FAILED — admin_users table already has rows. Refusing to overwrite.');
+      process.exit(2);
+    }
+    console.log(`[admin-bootstrap] OK — created admin row:`);
+    console.log(`  id:    ${result.id}`);
+    console.log(`  email: ${result.email}`);
+    console.log(`  role:  ${result.role}`);
+    console.log('');
+    console.log('Next steps:');
+    console.log('  1. Test login via the admin UI');
+    console.log('  2. Rotate the password');
+    console.log('  3. Remove ADMIN_EMAIL + ADMIN_PASSWORD env vars from prod');
+  } catch (err) {
+    console.error('[admin-bootstrap] FAILED with exception:', err);
+    process.exit(1);
+  }
+}
+
+void main();

--- a/src/lib/admin/admin-auth.ts
+++ b/src/lib/admin/admin-auth.ts
@@ -86,8 +86,23 @@ export async function verifyAdminSessionToken(token: string): Promise<AdminSessi
     if (sub !== 'admin') return null;
     const email = typeof payload.email === 'string' ? payload.email : '';
     if (!email) return null;
-    if (email.toLowerCase() !== getAdminEmail().toLowerCase()) return null;
-    return { email };
+    // RA-3027 — accept any email present in the `admin_users` table OR
+    // the legacy env-var email. The DB check is lazy-imported so this
+    // module stays usable in contexts that don't have Prisma loaded.
+    const emailLower = email.toLowerCase();
+    if (emailLower === getAdminEmail().toLowerCase()) return { email };
+    try {
+      const { prisma } = await import('@/lib/prisma');
+      const row = await prisma.adminUser.findUnique({
+        where: { email: emailLower },
+        select: { isActive: true },
+      });
+      if (row?.isActive) return { email };
+    } catch {
+      // DB unavailable — fall through to reject. Conservative on purpose
+      // since we don't want stolen tokens to validate during a DB outage.
+    }
+    return null;
   } catch {
     return null;
   }

--- a/src/lib/admin/admin-store.ts
+++ b/src/lib/admin/admin-store.ts
@@ -1,0 +1,104 @@
+// src/lib/admin/admin-store.ts — RA-3027.
+//
+// Database-backed admin lookup. Backwards-compatible with the env-var
+// gate: while the `admin_users` table is empty, login routes fall back
+// to ADMIN_EMAIL+ADMIN_PASSWORD env-vars. Once at least one row exists,
+// the env-var path is locked out (verifyAdminByEmail returns null on
+// no-match instead of bouncing to env).
+//
+// Password hashing: bcryptjs (cost 12) — matches the LmsUser pattern
+// already used in this codebase. No new crypto dep added.
+
+import { compare, hash } from 'bcryptjs';
+
+import { prisma } from '@/lib/prisma';
+import { getAdminEmail, getAdminPassword } from '@/lib/admin/admin-auth';
+
+const BCRYPT_COST = 12;
+
+export interface AdminRecord {
+  id: string;
+  email: string;
+  role: string;
+  isActive: boolean;
+}
+
+/** Number of admins currently in the DB. Used to decide whether the
+ *  env-var bootstrap path is still active. */
+export async function adminCount(): Promise<number> {
+  try {
+    return await prisma.adminUser.count();
+  } catch {
+    // If the migration hasn't run yet, the table doesn't exist —
+    // treat as zero so the env-var path stays alive.
+    return 0;
+  }
+}
+
+/** Look up an admin by email and verify the password. Returns the
+ *  AdminRecord on success, null on no-match / wrong-password / inactive.
+ *  Uses bcryptjs `compare` for constant-time verification. */
+export async function verifyAdminByEmail(
+  email: string,
+  password: string,
+): Promise<AdminRecord | null> {
+  const row = await prisma.adminUser.findUnique({
+    where: { email: email.toLowerCase() },
+  });
+  if (!row || !row.isActive) return null;
+  const ok = await compare(password, row.passwordHash);
+  if (!ok) return null;
+  return {
+    id: row.id,
+    email: row.email,
+    role: row.role,
+    isActive: row.isActive,
+  };
+}
+
+/** Bootstrap: copy the current ADMIN_EMAIL + ADMIN_PASSWORD env vars
+ *  into the table as the first admin. Idempotent — refuses to run if
+ *  any row already exists.
+ *
+ *  Invoked manually via the `db:admin-bootstrap` script (see
+ *  package.json after this PR merges). NOT called automatically on
+ *  login — that would create a race where a misconfigured env-var
+ *  could lock the operator out. */
+export async function bootstrapAdminFromEnv(): Promise<AdminRecord | null> {
+  if ((await adminCount()) > 0) {
+    return null; // Refuse — env-var path already retired.
+  }
+  const email = getAdminEmail().toLowerCase();
+  const password = getAdminPassword();
+  if (!email || !password) {
+    throw new Error(
+      'Cannot bootstrap admin: ADMIN_EMAIL or ADMIN_PASSWORD env var is unset.',
+    );
+  }
+  const passwordHash = await hash(password, BCRYPT_COST);
+  const row = await prisma.adminUser.create({
+    data: { email, passwordHash, role: 'admin' },
+  });
+  return {
+    id: row.id,
+    email: row.email,
+    role: row.role,
+    isActive: row.isActive,
+  };
+}
+
+/** Update `lastLoginAt` / `lastLoginIp`. Best-effort — failure is
+ *  swallowed because we don't want a stat-table outage to block login. */
+export async function recordAdminLogin(id: string, ip: string | null): Promise<void> {
+  try {
+    await prisma.adminUser.update({
+      where: { id },
+      data: {
+        lastLoginAt: new Date(),
+        lastLoginIp: ip,
+      },
+    });
+  } catch (err) {
+    console.warn('[admin-store] recordAdminLogin failed (non-fatal):', err);
+  }
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,70 @@
+// src/lib/rate-limit.ts — RA-3022.
+//
+// In-process token-bucket rate limiter. Defense-in-depth alongside
+// Cloudflare Turnstile + WAF — Turnstile is the strong signal, this is
+// the cheap second gate (no Cloudflare round-trip needed for the limit
+// check itself).
+//
+// Limitation: stateless serverless functions reset memory per cold
+// start, so the window is best-effort across invocations on the same
+// worker. For globally consistent quotas, migrate to Vercel KV /
+// Upstash Redis (`@upstash/ratelimit`) — left as a follow-up since
+// adding a dep + provisioning Redis is a separate workstream.
+//
+// In practice, Cloudflare Turnstile + an instance-local memory window
+// blocks the abuse class this fix targets (anonymous bots filling the
+// hub_submissions table). A determined attacker who fans out across
+// cold starts still gets stopped at Turnstile.
+
+interface Window {
+  count: number;
+  resetAt: number;
+}
+
+const STORE = new Map<string, Window>();
+
+// Cap the map at 10k entries so a flood of unique IPs can't OOM the
+// worker. LRU-style eviction is not needed — we just clear the map
+// when it crosses the threshold. Loses some active windows but keeps
+// memory bounded.
+const MAX_KEYS = 10_000;
+
+export interface RateLimitResult {
+  ok: boolean;
+  remaining: number;
+  resetAt: number;
+}
+
+export function applyRateLimit(
+  ip: string,
+  limit: number,
+  windowMs: number,
+): RateLimitResult {
+  const now = Date.now();
+
+  if (STORE.size > MAX_KEYS) {
+    STORE.clear();
+  }
+
+  const existing = STORE.get(ip);
+  if (!existing || existing.resetAt <= now) {
+    const fresh: Window = { count: 1, resetAt: now + windowMs };
+    STORE.set(ip, fresh);
+    return { ok: true, remaining: limit - 1, resetAt: fresh.resetAt };
+  }
+
+  existing.count += 1;
+  if (existing.count > limit) {
+    return { ok: false, remaining: 0, resetAt: existing.resetAt };
+  }
+  return {
+    ok: true,
+    remaining: limit - existing.count,
+    resetAt: existing.resetAt,
+  };
+}
+
+// Sentinel used by routes when client IP cannot be determined — keys
+// every "no-IP" caller into the same bucket so they can't bypass the
+// limit by spoofing missing headers.
+export const UNKNOWN_IP = "__unknown__";


### PR DESCRIPTION
## Summary
Replaces the single `ADMIN_EMAIL`+`ADMIN_PASSWORD` env-var gate with a Postgres-backed `admin_users` table. **Backwards-compatible by design** — the env-var login path remains active until at least one row exists in the table, so this PR can ship without locking the operator out.

## What changed

### New
- `prisma/schema.prisma` — `AdminUser` model (id, email unique, passwordHash, role, isActive, lastLoginAt, lastLoginIp, timestamps)
- `prisma/migrations/20260512000000_admin_users_table/migration.sql` — CREATE TABLE + unique index
- `src/lib/admin/admin-store.ts` — `adminCount`, `verifyAdminByEmail` (bcryptjs), `bootstrapAdminFromEnv`, `recordAdminLogin`
- `src/lib/rate-limit.ts` — same limiter as PR #112 (byte-identical — either PR can land first without conflict)
- `scripts/admin-bootstrap.ts` — operator script to seed first row from env vars
- `docs/ADMIN_AUTH_MIGRATION.md` — rollout sequence + rollback

### Modified
- `app/api/admin/login/route.ts` — rate-limit (10/15min/IP), constant-time env compare, DB-backed lookup when table populated, structured audit log on every success/failure
- `app/api/admin/users/search/route.ts` — bumped substring threshold 2→3 chars + audit log every search query
- `src/lib/admin/admin-auth.ts` — `verifyAdminSessionToken` now also accepts emails present in `admin_users` (lazy DB import + conservative-fail on DB outage)

## Rollout (operator)

```bash
pnpm prisma migrate deploy                    # 1. apply migration
npx tsx scripts/admin-bootstrap.ts            # 2. seed first row from env
# 3. test admin UI login (same creds)
# 4. eventually rotate password + remove env vars
```

Full rollout doc in `docs/ADMIN_AUTH_MIGRATION.md` including rollback.

## Out of scope (RA-3027 explicit follow-ups)
- TOTP MFA on admin login
- Dedicated `admin_audit_log` table (currently console-only)
- Self-serve password rotation flow
- Rotate `ADMIN_JWT_SECRET` after table migration completes

## CI note
Inherits the same `Frontend Tests` lint failure as #111 and #112 until CARSI#110 (RA-3015) merges with the `eslint.config.mjs` I just pushed there. Once #110 lands this PR will turn green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)