### PR TITLE
chore: add portfolio Identity block (Plan 05)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+@../Unite-Hub/.portfolio/PORTFOLIO.yaml
+
+## Identity (SSOT)
+**Canonical name:** CARSI
+**Aliases:** "Online Training LMS"
+**Canonical local path:** `D:$canon`
+**GitHub:** `CleanExpo/CARSI`
+
+> Registry: see `D:\Unite-Hub\.portfolio\PORTFOLIO.yaml` (single source of truth)
+
+---# CLAUDE.md
+
+Project-specific guidance for CARSI.


### PR DESCRIPTION
Adds @../Unite-Hub/.portfolio/PORTFOLIO.yaml reference + Identity block so agents in this repo load the registry on session start.