### PR TITLE
ci(deploy): gate dormant Python-backend deploy workflow to workflow_dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,19 @@
 name: Deploy
 
+# This workflow is currently dormant. It targets a Python backend in
+# `apps/backend/` (uv + pytest + Fly.io), but no such directory exists in
+# this repo — CARSI is a Next.js app deployed via Vercel (see vercel.json).
+# Every push-to-main run failed on the first step (`working-directory:
+# apps/backend` → "No such file or directory"), turning the main-branch run
+# red 100% of the time while providing zero signal. Gated to
+# workflow_dispatch-only until either:
+#   1. an `apps/backend/` Python service is actually added, OR
+#   2. this workflow is deleted in favour of CARSI's Vercel-only deploy path.
+#
+# ci.yml already documents the same removal pattern (see comment at the top
+# of its backend-tests section, dated 2026-04-19).
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: deploy-${{ github.ref }}


### PR DESCRIPTION
## Why this PR

\`deploy.yml\` has been failing on every push-to-main since CARSI became Next.js-only. The very first step (\`working-directory: apps/backend\`) errors immediately with "No such file or directory" — no \`apps/backend/\` exists. CARSI ships as a Next.js app at repo root and deploys via Vercel (\`vercel.json\`).

Symptom: daily red \`Deploy\` runs on main, contributing red signal with zero diagnostic value and obscuring real failures.

## Fix

Change only the \`on:\` trigger from \`push.branches=[main]\` to \`workflow_dispatch:\`. Job graph + Fly.io deploy logic preserved verbatim — if someone later adds the missing Python service, restoring the trigger is a one-line revert.

## Precedent

\`ci.yml\` documents the same removal pattern: its old \`backend-tests\` job was deleted on 2026-04-19 with an inline comment explaining why (no \`apps/backend\` exists). This PR is the same call applied to \`deploy.yml\`.

## Not in scope

- \`deploy-staging.yml\` has the same issue but only fires on the \`staging\` branch (last failure 2026-03-14). Not contributing to current main-branch noise → leaving alone.
- \`agent-pr-checks.yml\` greps \`apps/backend/src\` in a print-statement check that fails soft; not failing the workflow.
- \`security.yml\` — only references \`apps/backend\` in scan paths that handle missing dirs gracefully.

## Test plan

- [ ] CI on this PR is green.
- [ ] After merge: next push to main → no \`Deploy\` workflow run appears (auto-trigger gone).
- [ ] Manual trigger via Actions tab → \`Deploy\` → Run workflow still works for ad-hoc invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)