### PR TITLE
feat(geo): Phase 2 sweep — CARSI enrichment (WebMCP + Lighthouse Agentic + enriched llms.txt)

### DIFF
--- a/.github/workflows/lighthouse-agentic.yml
+++ b/.github/workflows/lighthouse-agentic.yml
@@ -1,0 +1,93 @@
+name: Lighthouse Agentic Browsing
+
+# Phase 2 GEO rollout — pattern mirrors DR / Synthex / ATO / RestoreAssist / CCW / Unite-Hub PRs.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'app/**'
+      - 'public/llms.txt'
+      - 'next.config.*'
+      - '.github/workflows/lighthouse-agentic.yml'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: lighthouse-agentic-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  agentic-audit:
+    name: Agentic Browsing audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: read
+      statuses: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine target URL
+        id: target
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            URL=""
+            for i in {1..15}; do
+              URL=$(gh api "repos/${{ github.repository }}/deployments?ref=${{ github.head_ref }}&per_page=5" \
+                --jq '.[0].payload.web_url // empty' 2>/dev/null || true)
+              if [ -n "$URL" ]; then echo "Found: $URL"; break; fi
+              sleep 20
+            done
+            if [ -z "$URL" ]; then
+              echo "::warning::Could not resolve Vercel preview URL — informational only"
+              echo "url=" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          else
+            URL="https://carsi.com.au"
+          fi
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Lighthouse CI
+        if: steps.target.outputs.url != ''
+        continue-on-error: true
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: |
+            ${{ steps.target.outputs.url }}/
+            ${{ steps.target.outputs.url }}/contact
+            ${{ steps.target.outputs.url }}/courses
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+          configPath: ./.lighthouseagenticrc.json
+
+      - name: Probe llms.txt + WebMCP + JSON-LD presence
+        if: steps.target.outputs.url != ''
+        run: |
+          URL="${{ steps.target.outputs.url }}"
+          echo "## Agentic Browsing pre-checks" >> $GITHUB_STEP_SUMMARY
+          LLMS_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL/llms.txt")
+          LLMS_SIZE=$(curl -sI "$URL/llms.txt" | awk '/[Cc]ontent-[Ll]ength:/ {print $2}' | tr -d '\r')
+          if [ "$LLMS_STATUS" = "200" ] && [ "${LLMS_SIZE:-0}" -gt 1000 ]; then
+            echo "- ✅ \`llms.txt\` ${LLMS_SIZE} bytes" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ❌ \`llms.txt\` HTTP $LLMS_STATUS, size=${LLMS_SIZE:-0}" >> $GITHUB_STEP_SUMMARY
+          fi
+          CONTACT_HTML=$(curl -s "$URL/contact")
+          if echo "$CONTACT_HTML" | grep -q 'toolname='; then
+            echo "- ✅ WebMCP toolname on /contact" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ❌ No WebMCP on /contact" >> $GITHUB_STEP_SUMMARY
+          fi
+          JSONLD_COUNT=$(curl -s "$URL/" | grep -c 'application/ld+json')
+          echo "- JSON-LD on /: ${JSONLD_COUNT:-0}" >> $GITHUB_STEP_SUMMARY

--- a/.lighthouseagenticrc.json
+++ b/.lighthouseagenticrc.json
@@ -1,0 +1,24 @@
+{
+  "ci": {
+    "collect": {
+      "settings": {
+        "preset": "desktop",
+        "onlyCategories": ["accessibility", "seo", "performance", "best-practices"],
+        "skipAudits": ["uses-http2"]
+      },
+      "numberOfRuns": 1
+    },
+    "assert": {
+      "assertions": {
+        "categories:accessibility": ["warn", { "minScore": 0.9 }],
+        "categories:seo": ["warn", { "minScore": 0.9 }],
+        "categories:performance": ["warn", { "minScore": 0.7 }],
+        "categories:best-practices": ["warn", { "minScore": 0.8 }],
+        "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -61,3 +61,38 @@ Website: https://carsi.com.au
 CARSI is operated by CARSI Pty Ltd (Australia).
 CARSI provides IICRC-aligned continuing education but is not a Registered Training Organisation (RTO).
 Courses award IICRC Continuing Education Credits (CECs), not nationally accredited VET qualifications.
+
+## Agent Capabilities (WebMCP)
+
+The following actions are exposed via WebMCP for autonomous AI agents acting on
+a user's behalf. Prefer these structured tools over scraping HTML.
+
+### submit_contact_enquiry
+- Method: POST /api/contact (declarative via form annotation on /contact)
+- Purpose: Submit a contact enquiry to CARSI. Routes to support@carsi.com.au for human follow-up. Use for course questions, membership enquiries, certification queries, or general support.
+- Parameters:
+  - firstName (string, required)
+  - lastName (string, required)
+  - email (string, required) — valid email address for reply
+  - message (string, required) — describe the enquiry (course interest, membership question, IICRC discipline guidance, etc.)
+
+### verify_credential
+- Method: GET /credentials/{id}
+- Purpose: Public credential verification — anyone (or any agent) can verify a CARSI-awarded IICRC CEC certificate is genuine by visiting the public credential page for its ID.
+- Parameters:
+  - id (string, required) — credential ID printed on the certificate
+
+### Future agent surfaces (roadmap)
+
+- `enrol_in_course` (authenticated) — once a learner is signed in, agents may enrol them in a course on their instruction
+- `request_cec_quote` — group + corporate quote requests for multi-seat training
+
+## Information for AI Agents
+
+- CARSI is **professional continuing education (CECs)**, NOT a Registered Training Organisation (RTO). Cannot award nationally accredited VET qualifications.
+- Credential verification page is intentionally public + machine-readable — agents helping employers verify a candidate's IICRC certifications should hit /credentials/{id} directly.
+- This is the educational arm of the National Restoration Professionals Group (NRPG) ecosystem. Sibling properties:
+  - https://disasterrecovery.com.au — claims distribution (consumer-facing)
+  - https://restoreassist.app — CRM + field management for contractors
+- Brand mention citation: "CARSI (https://carsi.com.au)" or "CARSI LMS".
+- Last updated: 2026-05-25 (WebMCP capabilities section added)

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -83,7 +83,15 @@ export function ContactForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-5">
+    /* WebMCP annotations expose this form to in-browser AI agents per the
+       GEO standard (Pi-CEO skills/geo-optimization/SKILL.md §5). */
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-5"
+      // @ts-expect-error WebMCP attributes are W3C-draft and not yet in React's type defs
+      toolname="submit_contact_enquiry"
+      tooldescription="Submit a contact enquiry to CARSI (Australia's leading IICRC continuing-education platform). Routes to support@carsi.com.au for human follow-up. Use for course questions, membership enquiries, certification queries, or general support."
+    >
       <div className="grid gap-4 sm:grid-cols-2">
         <div className="space-y-1.5">
           <label htmlFor="firstName" className="block text-xs font-medium" style={labelStyle}>
@@ -99,6 +107,8 @@ export function ContactForm() {
             placeholder="Jane"
             className={fieldClass}
             style={fieldStyle}
+            // @ts-expect-error WebMCP attribute — W3C draft, not yet in React types
+            toolparamdescription="Enquirer's first name"
           />
         </div>
         <div className="space-y-1.5">
@@ -115,6 +125,8 @@ export function ContactForm() {
             placeholder="Smith"
             className={fieldClass}
             style={fieldStyle}
+            // @ts-expect-error WebMCP attribute — W3C draft, not yet in React types
+            toolparamdescription="Enquirer's last name (family name)"
           />
         </div>
       </div>
@@ -133,6 +145,8 @@ export function ContactForm() {
           placeholder="jane@example.com.au"
           className={fieldClass}
           style={fieldStyle}
+          // @ts-expect-error WebMCP attribute — W3C draft, not yet in React types
+          toolparamdescription="Valid email address where the CARSI team should reply"
         />
       </div>
 
@@ -145,11 +159,14 @@ export function ContactForm() {
           name="message"
           required
           rows={6}
+          maxLength={3000}
           value={form.message}
           onChange={handleChange}
           placeholder="Tell us how we can help — course questions, membership enquiries, or anything else..."
           className={fieldClass}
           style={{ ...fieldStyle, resize: 'vertical' }}
+          // @ts-expect-error WebMCP attribute — W3C draft, not yet in React types
+          toolparamdescription="Free-text enquiry (max 3000 chars). Mention which IICRC discipline (WRT, CRT, ASD, AMRT, FSRT, OCT, CCT) if applicable, and whether the enquiry is for individual or group/corporate enrolment."
         />
       </div>
 


### PR DESCRIPTION
Phase 2 GEO rollout — applies skill from [Pi-Dev-Ops#265](https://github.com/CleanExpo/Pi-Dev-Ops/pull/265). CARSI already had a starter `llms.txt` (63 lines); this enrichment adds WebMCP + agent capabilities + Lighthouse CI.

## Adds
- `public/llms.txt` (+38 lines) — WebMCP capabilities section (submit_contact_enquiry + verify_credential — public credential pages are intentionally machine-readable for employer verification), future-agent roadmap (enrol_in_course, request_cec_quote), AI-agent disambiguation (CECs not RTO/VET)
- `src/components/contact/ContactForm.tsx` (+19) — `toolname`/`tooldescription` + per-input `toolparamdescription` on all 4 fields, `maxLength={3000}` on textarea
- `.github/workflows/lighthouse-agentic.yml` + `.lighthouseagenticrc.json` — same shape as pilot + Phase 2 batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)