### PR TITLE
Feat/cec admin and enrollment tools

### DIFF
--- a/app/(admin)/admin/layout.tsx
+++ b/app/(admin)/admin/layout.tsx
@@ -1,14 +1,30 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
 import { AdminAccessDenied } from '@/components/admin/AdminAccessDenied';
 import { AdminShell } from '@/components/admin/AdminShell';
+import { isLmsClaimsAllowedAdminPanel } from '@/lib/admin/admin-auth';
 import { getAdminSessionOrNull } from '@/lib/admin/admin-session';
+import { verifySessionToken } from '@/lib/auth/session-jwt';
 
 /** Avoid DB access during `next build` (Prisma TLS to managed Postgres can fail in the build environment). */
 export const dynamic = 'force-dynamic';
 
 export default async function AdminSectionLayout({ children }: { children: React.ReactNode }) {
   const session = await getAdminSessionOrNull();
-  if (!session) {
-    return <AdminAccessDenied />;
+  if (session) {
+    return <AdminShell>{children}</AdminShell>;
   }
-  return <AdminShell>{children}</AdminShell>;
+
+  const cookieStore = await cookies();
+  const lmsToken =
+    cookieStore.get('auth_token')?.value ?? cookieStore.get('carsi_token')?.value;
+  if (lmsToken) {
+    const claims = await verifySessionToken(lmsToken);
+    if (claims && !isLmsClaimsAllowedAdminPanel(claims)) {
+      redirect('/dashboard/student');
+    }
+  }
+
+  return <AdminAccessDenied />;
 }

--- a/app/(dashboard)/dashboard/credentials/[credentialId]/page.tsx
+++ b/app/(dashboard)/dashboard/credentials/[credentialId]/page.tsx
@@ -8,17 +8,28 @@ export const dynamic = 'force-dynamic';
 
 export default async function DashboardCredentialPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ credentialId: string }>;
+  searchParams: Promise<{ completed?: string; course?: string }>;
 }) {
   const { credentialId } = await params;
+  const query = await searchParams;
   const origin = await getServerOrigin();
   const credential = await getPublicCredentialJson(credentialId, origin);
   if (!credential) notFound();
 
+  const courseSlug =
+    typeof query.course === 'string' && query.course.trim() ? query.course.trim() : null;
+
   return (
-    <main className="mx-auto w-full max-w-4xl">
-      <CredentialVerificationPageContent credential={credential} credentialId={credentialId} />
+    <main className="mx-auto w-full max-w-4xl px-4 pb-12">
+      <CredentialVerificationPageContent
+        credential={credential}
+        credentialId={credentialId}
+        justCompleted={query.completed === '1'}
+        courseSlug={courseSlug}
+      />
     </main>
   );
 }

--- a/app/(dashboard)/dashboard/student/page.tsx
+++ b/app/(dashboard)/dashboard/student/page.tsx
@@ -12,9 +12,9 @@ import { PopularForYouStrip } from '@/components/lms/PopularForYouStrip';
 import { PushNotificationPrompt } from '@/components/lms/PushNotificationPrompt';
 import { RenewalCockpit } from '@/components/lms/RenewalCockpit';
 import { apiClient } from '@/lib/api/client';
-import Link from 'next/link';
-import { ArrowRight, Award, BookOpen, Flame, Sparkles, TrendingUp } from 'lucide-react';
 import type { RenewalCourseSuggestion } from '@/types/renewal';
+import { ArrowRight, Award, BookOpen, Flame, Sparkles, TrendingUp } from 'lucide-react';
+import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
 
 interface LevelData {
@@ -268,11 +268,9 @@ export default function StudentDashboardPage() {
               <div className="rounded-xl border border-white/[0.08] bg-white/[0.04] p-4 backdrop-blur-sm transition-colors hover:border-[#2490ed]/25">
                 <div className="flex items-center gap-2 text-[#2490ed]">
                   <TrendingUp className="h-4 w-4" aria-hidden />
-                  <span className="text-[10px] font-semibold tracking-wider uppercase">
-                    Level
-                  </span>
+                  <span className="text-[10px] font-semibold tracking-wider uppercase">Level</span>
                 </div>
-                <p className="mt-2 text-2xl font-bold tabular-nums text-white">
+                <p className="mt-2 text-2xl font-bold text-white tabular-nums">
                   {loading.level ? '—' : (level?.current_level ?? '—')}
                 </p>
                 <p className="mt-0.5 line-clamp-2 text-xs text-white/45">
@@ -282,11 +280,9 @@ export default function StudentDashboardPage() {
               <div className="rounded-xl border border-white/[0.08] bg-white/[0.04] p-4 backdrop-blur-sm transition-colors hover:border-orange-500/25">
                 <div className="flex items-center gap-2 text-orange-300/90">
                   <Flame className="h-4 w-4" aria-hidden />
-                  <span className="text-[10px] font-semibold tracking-wider uppercase">
-                    Streak
-                  </span>
+                  <span className="text-[10px] font-semibold tracking-wider uppercase">Streak</span>
                 </div>
-                <p className="mt-2 text-2xl font-bold tabular-nums text-white">
+                <p className="mt-2 text-2xl font-bold text-white tabular-nums">
                   {loading.level ? '—' : (level?.current_streak ?? 0)}
                 </p>
                 <p className="mt-0.5 text-xs text-white/45">Active days</p>
@@ -298,7 +294,7 @@ export default function StudentDashboardPage() {
                     Courses
                   </span>
                 </div>
-                <p className="mt-2 text-2xl font-bold tabular-nums text-white">
+                <p className="mt-2 text-2xl font-bold text-white tabular-nums">
                   {enrollmentsLoading ? '—' : enrollments.length}
                 </p>
                 <p className="mt-0.5 text-xs text-white/45">Enrolled</p>
@@ -306,11 +302,9 @@ export default function StudentDashboardPage() {
               <div className="rounded-xl border border-white/[0.08] bg-white/[0.04] p-4 backdrop-blur-sm transition-colors hover:border-violet-400/25">
                 <div className="flex items-center gap-2 text-violet-300/90">
                   <Award className="h-4 w-4" aria-hidden />
-                  <span className="text-[10px] font-semibold tracking-wider uppercase">
-                    CECs
-                  </span>
+                  <span className="text-[10px] font-semibold tracking-wider uppercase">CECs</span>
                 </div>
-                <p className="mt-2 text-2xl font-bold tabular-nums text-white">
+                <p className="mt-2 text-2xl font-bold text-white tabular-nums">
                   {loading.level
                     ? '—'
                     : level?.total_cec_lifetime != null
@@ -334,7 +328,10 @@ export default function StudentDashboardPage() {
           className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_90%_60%_at_50%_-30%,rgba(36,144,237,0.22),transparent_55%)]"
           aria-hidden
         />
-        <div className="pointer-events-none absolute -right-24 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full bg-[#2490ed]/10 blur-3xl" aria-hidden />
+        <div
+          className="pointer-events-none absolute top-1/2 -right-24 h-64 w-64 -translate-y-1/2 rounded-full bg-[#2490ed]/10 blur-3xl"
+          aria-hidden
+        />
         <div className="relative px-5 py-8 sm:px-10 sm:py-10">
           <div className="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
             <div className="flex min-w-0 gap-4 sm:gap-5">
@@ -350,7 +347,7 @@ export default function StudentDashboardPage() {
                     My courses
                   </h2>
                   {!enrollmentsLoading && enrollments.length > 0 ? (
-                    <span className="rounded-full border border-white/10 bg-white/5 px-3 py-0.5 text-xs font-medium tabular-nums text-white/55">
+                    <span className="rounded-full border border-white/10 bg-white/5 px-3 py-0.5 text-xs font-medium text-white/55 tabular-nums">
                       {enrollments.length} enrolled
                     </span>
                   ) : null}
@@ -395,7 +392,7 @@ export default function StudentDashboardPage() {
             ) : enrollments.length === 0 && sub?.has_subscription ? (
               <div className="relative overflow-hidden rounded-2xl border border-[#2490ed]/25 bg-gradient-to-br from-[#2490ed]/15 via-white/5 to-transparent p-8 text-center sm:p-12">
                 <div
-                  className="pointer-events-none absolute -left-16 top-0 h-40 w-40 rounded-full bg-emerald-400/10 blur-3xl"
+                  className="pointer-events-none absolute top-0 -left-16 h-40 w-40 rounded-full bg-emerald-400/10 blur-3xl"
                   aria-hidden
                 />
                 <div className="relative mx-auto max-w-md">
@@ -406,8 +403,8 @@ export default function StudentDashboardPage() {
                     Subscription active — your catalogue is unlocked
                   </p>
                   <p className="mt-2 text-sm leading-relaxed text-white/50">
-                    Enrol by opening any course. Your first visit creates the enrolment automatically so
-                    progress saves here.
+                    Enrol by opening any course. Your first visit creates the enrolment
+                    automatically so progress saves here.
                   </p>
                   <Link
                     href="/dashboard/courses"
@@ -439,7 +436,6 @@ export default function StudentDashboardPage() {
           </div>
         </div>
       </section>
-
     </div>
   );
 }

--- a/app/(dashboard)/dashboard/team/page.tsx
+++ b/app/(dashboard)/dashboard/team/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useCallback, useEffect, useState } from 'react';
+import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 
@@ -110,11 +110,13 @@ function TeamDashboardPage() {
   const [setupLoading, setSetupLoading] = useState(false);
 
   const needsCheckoutSetup = Boolean(sessionId && !user);
+  const hasSyncedRef = useRef(false);
+  const initialSessionIdRef = useRef(sessionId);
 
-  const syncTeam = useCallback(async () => {
+  const syncTeam = useCallback(async (activateSessionId?: string) => {
     const data = await apiClient.post<{ team: TeamPayload | null; detail?: string }>(
       '/api/lms/teams/activate-purchase',
-      sessionId ? { session_id: sessionId } : {},
+      activateSessionId ? { session_id: activateSessionId } : {},
     );
     if (data.team) {
       setTeam(data.team);
@@ -129,7 +131,7 @@ function TeamDashboardPage() {
       return me.team;
     }
     return null;
-  }, [sessionId]);
+  }, []);
 
   useEffect(() => {
     if (!sessionId || user) return;
@@ -150,21 +152,25 @@ function TeamDashboardPage() {
       setLoading(false);
       return;
     }
+    if (hasSyncedRef.current) return;
 
     let cancelled = false;
+    const activateSessionId = initialSessionIdRef.current ?? undefined;
+
     (async () => {
       setLoading(true);
       setError(null);
       try {
-        await syncTeam();
+        await syncTeam(activateSessionId);
       } catch (err) {
         if (!cancelled) {
           setError(err instanceof ApiClientError ? err.message : 'Failed to load team');
         }
       } finally {
         if (!cancelled) {
+          hasSyncedRef.current = true;
           setLoading(false);
-          if (sessionId) {
+          if (activateSessionId) {
             const params = new URLSearchParams(searchParams.toString());
             params.delete('session_id');
             const qs = params.toString();
@@ -177,7 +183,7 @@ function TeamDashboardPage() {
     return () => {
       cancelled = true;
     };
-  }, [user, sessionId, syncTeam, router, searchParams]);
+  }, [user, syncTeam, router, searchParams]);
 
   async function handleCheckoutSetup(e: React.FormEvent) {
     e.preventDefault();

--- a/app/(dashboard)/dashboard/team/page.tsx
+++ b/app/(dashboard)/dashboard/team/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { Suspense } from 'react';
+import { Suspense, useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+
 import { useAuth } from '@/components/auth/auth-provider';
 import { ErrorBanner } from '@/components/lms/ErrorBanner';
 import { TEAM_TIERS, type TeamBundleTierId } from '@/lib/lms/pricing-tiers';
 import { apiClient, ApiClientError } from '@/lib/api/client';
-import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
-import { useCallback, useEffect, useState } from 'react';
 
 interface TeamMember {
   user_id: string;
@@ -23,52 +23,209 @@ interface PendingInvite {
   expires_at: string;
 }
 
+interface TeamCoursePurchase {
+  id: string;
+  course_slug: string;
+  course_title: string;
+  seat_limit: number;
+  seats_used: number;
+  seats_remaining: number;
+  purchased_at: string;
+}
+
+interface TeamCourseSeatPool {
+  course_slug: string;
+  course_title: string;
+  seat_limit: number;
+  seats_used: number;
+  seats_remaining: number;
+  purchase_count: number;
+  purchases: TeamCoursePurchase[];
+}
+
+interface TeamMemberAssignedCourse {
+  slug: string;
+  title: string;
+}
+
 interface TeamPayload {
   id: string;
   name: string;
   slug: string;
   bundle_tier: string;
-  seat_limit: number;
-  seats_used: number;
   is_owner: boolean;
-  members: TeamMember[];
-  pending_invites: PendingInvite[];
+  course_slug?: string | null;
+  seat_limit?: number;
+  seats_used?: number;
+  members?: TeamMember[];
+  pending_invites?: PendingInvite[];
+  course_purchases?: TeamCoursePurchase[];
+  course_seat_pools?: TeamCourseSeatPool[];
+  added_by?: { full_name: string | null; email: string };
+  my_team_courses?: TeamMemberAssignedCourse[];
 }
 
 function TeamDashboardPage() {
   const { user } = useAuth();
+  const router = useRouter();
   const searchParams = useSearchParams();
+
+  const sessionId = searchParams.get('session_id');
+  const fromPurchase = searchParams.get('from_purchase') === '1';
+  const purchasedCourse = searchParams.get('course');
+  const purchasedSeats = searchParams.get('seats');
   const createTier = searchParams.get('create') as TeamBundleTierId | null;
+  const showAnnualPlanForm = Boolean(
+    createTier && TEAM_TIERS.some((t) => t.id === createTier),
+  );
 
   const [team, setTeam] = useState<TeamPayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [teamName, setTeamName] = useState('');
-  const [selectedTier, setSelectedTier] = useState<TeamBundleTierId>(
-    createTier && TEAM_TIERS.some((t) => t.id === createTier) ? createTier : 'starter'
-  );
-  const [inviteEmail, setInviteEmail] = useState('');
-  const [inviteUrl, setInviteUrl] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
-  const loadTeam = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await apiClient.get<{ team: TeamPayload | null }>('/api/lms/teams/me');
+  const [teamName, setTeamName] = useState('My team');
+  const [editingName, setEditingName] = useState(false);
+  const [selectedTier, setSelectedTier] = useState<TeamBundleTierId>(
+    createTier && TEAM_TIERS.some((t) => t.id === createTier) ? createTier : 'starter',
+  );
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [assignableCourses, setAssignableCourses] = useState<
+    {
+      slug: string;
+      title: string;
+      is_team_purchase_course: boolean;
+      seat_limit?: number;
+      seats_used?: number;
+      seats_remaining?: number;
+      team_purchase_count?: number;
+    }[]
+  >([]);
+  const [selectedCourseSlugs, setSelectedCourseSlugs] = useState<string[]>([]);
+  const [coursesLoading, setCoursesLoading] = useState(false);
+
+  const [checkoutEmail, setCheckoutEmail] = useState('');
+  const [setupPassword, setSetupPassword] = useState('');
+  const [setupLoading, setSetupLoading] = useState(false);
+
+  const needsCheckoutSetup = Boolean(sessionId && !user);
+
+  const syncTeam = useCallback(async () => {
+    const data = await apiClient.post<{ team: TeamPayload | null; detail?: string }>(
+      '/api/lms/teams/activate-purchase',
+      sessionId ? { session_id: sessionId } : {},
+    );
+    if (data.team) {
       setTeam(data.team);
-    } catch (e) {
-      setError(e instanceof ApiClientError ? e.message : 'Failed to load team');
-    } finally {
-      setLoading(false);
+      setTeamName(data.team.name);
+      return data.team;
     }
-  }, []);
+    if (data.detail) setError(data.detail);
+    const me = await apiClient.get<{ team: TeamPayload | null }>('/api/lms/teams/me');
+    if (me.team) {
+      setTeam(me.team);
+      setTeamName(me.team.name);
+      return me.team;
+    }
+    return null;
+  }, [sessionId]);
 
   useEffect(() => {
-    if (user) void loadTeam();
-  }, [user, loadTeam]);
+    if (!sessionId || user) return;
+    let cancelled = false;
+    fetch(`/api/lms/checkout/session?session_id=${encodeURIComponent(sessionId)}`)
+      .then((r) => r.json() as Promise<{ email?: string }>)
+      .then((data) => {
+        if (!cancelled && data.email) setCheckoutEmail(data.email);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, user]);
 
-  async function handleCreateTeam(e: React.FormEvent) {
+  useEffect(() => {
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        await syncTeam();
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof ApiClientError ? err.message : 'Failed to load team');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+          if (sessionId) {
+            const params = new URLSearchParams(searchParams.toString());
+            params.delete('session_id');
+            const qs = params.toString();
+            router.replace(qs ? `/dashboard/team?${qs}` : '/dashboard/team');
+          }
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user, sessionId, syncTeam, router, searchParams]);
+
+  async function handleCheckoutSetup(e: React.FormEvent) {
+    e.preventDefault();
+    if (!sessionId || setupPassword.length < 8) return;
+    setSetupLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/lms/enrollments/guest-complete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          session_id: sessionId,
+          password: setupPassword,
+          team_name: teamName,
+        }),
+      });
+      const data = (await res.json().catch(() => ({}))) as { detail?: string; learn_url?: string };
+      if (!res.ok) {
+        setError(data.detail ?? 'Could not finish setup');
+        return;
+      }
+      sessionStorage.removeItem('carsi_guest_checkout');
+      window.location.href = data.learn_url ?? '/dashboard/team?from_purchase=1';
+    } catch {
+      setError('Something went wrong. Please try again.');
+    } finally {
+      setSetupLoading(false);
+    }
+  }
+
+  async function handleSaveTeamName(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const data = await apiClient.patch<{ name: string }>('/api/lms/teams/me', { name: teamName });
+      setTeam((t) => (t ? { ...t, name: data.name } : t));
+      setEditingName(false);
+      setSuccess('Team name saved.');
+    } catch (err) {
+      setError(err instanceof ApiClientError ? err.message : 'Could not save team name');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleCreateAnnualTeam(e: React.FormEvent) {
     e.preventDefault();
     setBusy(true);
     setError(null);
@@ -77,7 +234,7 @@ function TeamDashboardPage() {
         name: teamName,
         bundle_tier: selectedTier,
       });
-      await loadTeam();
+      await syncTeam();
     } catch (err) {
       setError(err instanceof ApiClientError ? err.message : 'Could not create team');
     } finally {
@@ -85,24 +242,117 @@ function TeamDashboardPage() {
     }
   }
 
+  const loadAssignableCourses = useCallback(async () => {
+    setCoursesLoading(true);
+    try {
+      const data = await apiClient.get<{
+        courses: { slug: string; title: string; is_team_purchase_course: boolean }[];
+      }>('/api/lms/teams/assignable-courses');
+      const list = data.courses ?? [];
+      setAssignableCourses(list);
+      setSelectedCourseSlugs((prev) => {
+        if (prev.length > 0) return prev.filter((s) => list.some((c) => c.slug === s));
+        const defaults = list.filter((c) => c.is_team_purchase_course).map((c) => c.slug);
+        if (defaults.length > 0) return defaults;
+        return list.length === 1 ? [list[0]!.slug] : [];
+      });
+    } catch {
+      setAssignableCourses([]);
+    } finally {
+      setCoursesLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (user && team?.is_owner) void loadAssignableCourses();
+  }, [user, team?.is_owner, team?.id, loadAssignableCourses]);
+
+  function toggleCourseSlug(slug: string) {
+    setSelectedCourseSlugs((prev) =>
+      prev.includes(slug) ? prev.filter((s) => s !== slug) : [...prev, slug],
+    );
+  }
+
   async function handleInvite(e: React.FormEvent) {
     e.preventDefault();
     if (!team) return;
+    if (selectedCourseSlugs.length === 0) {
+      setError('Select at least one course for this person.');
+      return;
+    }
     setBusy(true);
     setError(null);
-    setInviteUrl(null);
+    setSuccess(null);
     try {
-      const data = await apiClient.post<{ invite_url: string }>('/api/lms/teams/invite', {
+      const data = await apiClient.post<{ message?: string; email?: string }>('/api/lms/teams/invite', {
         email: inviteEmail,
+        course_slugs: selectedCourseSlugs,
       });
-      setInviteUrl(data.invite_url);
       setInviteEmail('');
-      await loadTeam();
+      setSuccess(data.message ?? `Added ${data.email}. They will receive an email with access details.`);
+      await syncTeam();
     } catch (err) {
-      setError(err instanceof ApiClientError ? err.message : 'Could not send invite');
+      setError(err instanceof ApiClientError ? err.message : 'Could not add team member');
     } finally {
       setBusy(false);
     }
+  }
+
+  if (needsCheckoutSetup) {
+    return (
+      <div className="mx-auto max-w-lg space-y-6">
+        <header>
+          <p className="text-[11px] font-semibold tracking-[0.2em] text-[#2490ed]/80 uppercase">
+            Team setup
+          </p>
+          <h1 className="mt-2 text-2xl font-bold text-white">Your team is ready</h1>
+          <p className="mt-2 text-sm text-white/50">
+            Payment received{purchasedSeats ? ` for ${purchasedSeats} seats` : ''}. Name your team,
+            set a password, then add learners by email.
+          </p>
+        </header>
+        {error ? <ErrorBanner message={error} /> : null}
+        <form
+          onSubmit={handleCheckoutSetup}
+          className="space-y-4 rounded-2xl border border-white/10 p-6"
+        >
+          {checkoutEmail ? (
+            <p className="text-sm text-white/55">
+              Account email: <span className="text-white/85">{checkoutEmail}</span>
+            </p>
+          ) : null}
+          <label className="block text-sm text-white/70">
+            Team name
+            <input
+              required
+              minLength={2}
+              value={teamName}
+              onChange={(e) => setTeamName(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-white/12 bg-black/30 px-3 py-2 text-white"
+              placeholder="e.g. Acme Restoration"
+            />
+          </label>
+          <label className="block text-sm text-white/70">
+            Password (for your CARSI account)
+            <input
+              required
+              type="password"
+              minLength={8}
+              value={setupPassword}
+              onChange={(e) => setSetupPassword(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-white/12 bg-black/30 px-3 py-2 text-white"
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={setupLoading}
+            className="w-full rounded-xl bg-[#2490ed] py-2.5 text-sm font-semibold text-white disabled:opacity-50"
+          >
+            {setupLoading ? 'Saving…' : 'Continue to add team members'}
+          </button>
+        </form>
+      </div>
+    );
   }
 
   if (!user) {
@@ -117,24 +367,30 @@ function TeamDashboardPage() {
   }
 
   if (loading) {
-    return <p className="text-white/50">Loading team…</p>;
+    return <p className="text-white/50">Loading your team…</p>;
   }
 
-  if (!team) {
+  if (!team && showAnnualPlanForm) {
     return (
       <div className="mx-auto max-w-lg space-y-6">
         <header>
           <p className="text-[11px] font-semibold tracking-[0.2em] text-[#2490ed]/80 uppercase">
             Teams
           </p>
-          <h1 className="mt-2 text-2xl font-bold text-white">Create your team</h1>
+          <h1 className="mt-2 text-2xl font-bold text-white">Annual team plan</h1>
           <p className="mt-2 text-sm text-white/50">
-            Seat-based training for your restoration crew. Billing integration completes in a later
-            phase — your team is ready for invites now.
+            Subscribe to a yearly team bundle from{' '}
+            <Link href="/pricing" className="text-[#7ec5ff] hover:underline">
+              pricing
+            </Link>
+            .
           </p>
         </header>
         {error ? <ErrorBanner message={error} /> : null}
-        <form onSubmit={handleCreateTeam} className="space-y-4 rounded-2xl border border-white/10 p-6">
+        <form
+          onSubmit={handleCreateAnnualTeam}
+          className="space-y-4 rounded-2xl border border-white/10 p-6"
+        >
           <label className="block text-sm text-white/70">
             Team name
             <input
@@ -142,7 +398,6 @@ function TeamDashboardPage() {
               value={teamName}
               onChange={(e) => setTeamName(e.target.value)}
               className="mt-1 w-full rounded-lg border border-white/12 bg-black/30 px-3 py-2 text-white"
-              placeholder="e.g. Acme Restoration"
             />
           </label>
           <label className="block text-sm text-white/70">
@@ -166,15 +421,121 @@ function TeamDashboardPage() {
           >
             {busy ? 'Creating…' : 'Create team'}
           </button>
-          <p className="text-center text-xs text-white/40">
-            <Link href="/pricing" className="text-[#7ec5ff] hover:underline">
-              Compare team plans
-            </Link>
-          </p>
         </form>
       </div>
     );
   }
+
+  if (!team) {
+    return (
+      <div className="mx-auto max-w-lg space-y-4">
+        <h1 className="text-xl font-bold text-white">No team on this account</h1>
+        <p className="text-sm text-white/55">
+          Course team seats are created when you complete team checkout on a course page. If you
+          already paid, try restoring your purchase below.
+        </p>
+        {error ? <ErrorBanner message={error} /> : null}
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={async () => {
+              setLoading(true);
+              setError(null);
+              try {
+                await syncTeam();
+              } catch (err) {
+                setError(err instanceof ApiClientError ? err.message : 'Could not restore team');
+              } finally {
+                setLoading(false);
+              }
+            }}
+            className="rounded-lg bg-[#2490ed] px-4 py-2 text-sm font-semibold text-white"
+          >
+            Restore my course team
+          </button>
+          <Link
+            href="/courses"
+            className="rounded-lg border border-white/15 px-4 py-2 text-sm text-white/70 hover:text-white"
+          >
+            Browse courses
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (!team.is_owner) {
+    const addedBy =
+      team.added_by?.full_name?.trim() ||
+      team.added_by?.email?.split('@')[0] ||
+      'Your team owner';
+    const courses = team.my_team_courses ?? [];
+
+    return (
+      <div className="mx-auto max-w-lg space-y-6">
+        <header>
+          <p className="text-[11px] font-semibold tracking-[0.2em] text-[#2490ed]/80 uppercase">
+            Team access
+          </p>
+          <h1 className="mt-2 text-2xl font-bold text-white">{team.name}</h1>
+          <p className="mt-2 text-sm text-white/55">
+            You were added to this team by{' '}
+            <span className="font-medium text-white/85">{addedBy}</span>
+            {team.added_by?.email ? (
+              <span className="text-white/40"> ({team.added_by.email})</span>
+            ) : null}
+            .
+          </p>
+        </header>
+
+        <section className="rounded-2xl border border-white/10 p-6">
+          <h2 className="text-sm font-semibold text-white">Your courses</h2>
+          <p className="mt-1 text-xs text-white/45">
+            Only the courses your team owner assigned to you are listed here.
+          </p>
+          {courses.length === 0 ? (
+            <p className="mt-4 text-sm text-white/50">
+              No courses assigned yet. Ask your team owner if you expected access.
+            </p>
+          ) : (
+            <ul className="mt-4 space-y-3">
+              {courses.map((c) => (
+                <li
+                  key={c.slug}
+                  className="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-black/20 px-4 py-3"
+                >
+                  <span className="text-sm font-medium text-white/90">{c.title}</span>
+                  <Link
+                    href={`/dashboard/learn/${encodeURIComponent(c.slug)}`}
+                    className="shrink-0 rounded-lg bg-[#2490ed] px-3 py-1.5 text-xs font-semibold text-white hover:bg-[#1a7fd4]"
+                  >
+                    Open course
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <p className="text-center text-xs text-white/35">
+          <Link href="/dashboard/student" className="text-[#7ec5ff] hover:underline">
+            Go to your dashboard
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  const pools = team.course_seat_pools ?? [];
+  const purchases = team.course_purchases ?? [];
+  const isCourseTeam =
+    team.bundle_tier === 'course_purchase' &&
+    (pools.length > 0 || purchases.length > 0 || Boolean(team.course_slug));
+  const seatsRemaining = Math.max(0, (team.seat_limit ?? 0) - (team.seats_used ?? 0));
+  const hasPoolSeats = pools.some((p) => p.seats_remaining > 0);
+  const canInviteMore = isCourseTeam ? hasPoolSeats : seatsRemaining > 0;
+  const showPurchaseBanner = fromPurchase || Boolean(isCourseTeam);
+  const showNameEditor = team.is_owner && (editingName || fromPurchase || isCourseTeam);
 
   return (
     <div className="mx-auto max-w-2xl space-y-8">
@@ -182,18 +543,130 @@ function TeamDashboardPage() {
         <p className="text-[11px] font-semibold tracking-[0.2em] text-[#2490ed]/80 uppercase">
           Teams
         </p>
-        <h1 className="mt-2 text-2xl font-bold text-white">{team.name}</h1>
-        <p className="mt-1 text-sm text-white/45">
-          {team.bundle_tier.replace(/_/g, ' ')} · {team.seats_used}/{team.seat_limit} seats used
-        </p>
+        {showNameEditor ? (
+          <form onSubmit={handleSaveTeamName} className="mt-3 space-y-2">
+            <label className="block text-sm text-white/70">
+              Team name
+              <input
+                required
+                minLength={2}
+                value={teamName}
+                onChange={(e) => setTeamName(e.target.value)}
+                className="mt-1 w-full rounded-lg border border-white/12 bg-black/30 px-3 py-2 text-lg font-bold text-white"
+              />
+            </label>
+            <button
+              type="submit"
+              disabled={busy}
+              className="rounded-lg bg-[#2490ed] px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+            >
+              {busy ? 'Saving…' : 'Save name'}
+            </button>
+          </form>
+        ) : (
+          <>
+            <h1 className="mt-2 text-2xl font-bold text-white">{team.name}</h1>
+            {team.is_owner ? (
+              <button
+                type="button"
+                onClick={() => {
+                  setTeamName(team.name);
+                  setEditingName(true);
+                }}
+                className="mt-1 text-xs text-[#7ec5ff] hover:underline"
+              >
+                Edit team name
+              </button>
+            ) : null}
+          </>
+        )}
+        {!isCourseTeam ? (
+          <p className="mt-2 text-sm text-white/45">
+            {team.bundle_tier.replace(/_/g, ' ')} · {team.seats_used}/{team.seat_limit} seats used
+          </p>
+        ) : null}
       </header>
 
+      {isCourseTeam && purchases.length > 0 ? (
+        <section className="rounded-2xl border border-white/10 p-6">
+          <h2 className="text-sm font-semibold text-white">Team course purchases</h2>
+          <p className="mt-1 text-xs text-white/45">
+            Each checkout is listed separately. Seat use is counted per course.
+          </p>
+          <ul className="mt-4 space-y-3">
+            {purchases.map((p) => {
+              const pool = pools.find((x) => x.course_slug === p.course_slug);
+              return (
+                <li
+                  key={p.id}
+                  className="rounded-xl border border-white/10 bg-black/20 px-4 py-3 text-sm"
+                >
+                  <div className="flex flex-wrap items-baseline justify-between gap-2">
+                    <span className="font-medium text-white/90">{p.course_title}</span>
+                    <span className="text-xs text-[#7ec5ff]">Team purchase</span>
+                  </div>
+                  <p className="mt-1 text-white/55">
+                    {p.seat_limit} seats in this purchase
+                    {pool && (pool.purchase_count > 1 || pool.purchases.length > 1) ? (
+                      <span className="text-white/40">
+                        {' '}
+                        · {pool.seats_used}/{pool.seat_limit} used across{' '}
+                        {pool.purchase_count} purchases for this course
+                      </span>
+                    ) : (
+                      <span className="text-white/40">
+                        {' '}
+                        · {p.seats_used}/{p.seat_limit} seats used
+                      </span>
+                    )}
+                  </p>
+                </li>
+              );
+            })}
+          </ul>
+          {pools.some((p) => p.purchase_count > 1) ? (
+            <ul className="mt-4 space-y-2 border-t border-white/8 pt-4 text-xs text-white/50">
+              {pools
+                .filter((p) => p.purchase_count > 1)
+                .map((p) => (
+                  <li key={p.course_slug}>
+                    <strong className="text-white/70">{p.course_title}</strong>:{' '}
+                    {p.purchase_count} team purchases · {p.seat_limit} seats total ·{' '}
+                    {p.seats_used}/{p.seat_limit} used
+                  </li>
+                ))}
+            </ul>
+          ) : null}
+        </section>
+      ) : isCourseTeam ? (
+        <p className="text-sm text-white/45">
+          Course · {(purchasedCourse ?? team.course_slug ?? '').replace(/-/g, ' ')} ·{' '}
+          {team.seats_used}/{team.seat_limit} seats used
+        </p>
+      ) : null}
+
+      {showPurchaseBanner ? (
+        <div className="rounded-2xl border border-[#2490ed]/35 bg-[#2490ed]/10 p-4 text-sm text-white/80">
+          <p className="font-semibold text-white">Add your team</p>
+          <p className="mt-1 text-white/60">
+            {isCourseTeam && pools.length > 0
+              ? 'Pick which courses they get — the email only mentions those. Each course has its own seat pool from your team purchases.'
+              : `Invite up to ${seatsRemaining} more ${seatsRemaining === 1 ? 'learner' : 'learners'}. Pick which of your courses they get — the email only mentions those.`}
+          </p>
+        </div>
+      ) : null}
+
       {error ? <ErrorBanner message={error} /> : null}
+      {success ? (
+        <p className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
+          {success}
+        </p>
+      ) : null}
 
       <section className="rounded-2xl border border-white/10 p-6">
         <h2 className="text-sm font-semibold text-white">Members</h2>
         <ul className="mt-3 divide-y divide-white/8">
-          {team.members.map((m) => (
+          {(team.members ?? []).map((m) => (
             <li key={m.user_id} className="flex justify-between py-2 text-sm">
               <span className="text-white/85">{m.full_name || m.email}</span>
               <span className="text-white/40 capitalize">{m.role}</span>
@@ -202,39 +675,94 @@ function TeamDashboardPage() {
         </ul>
       </section>
 
-      {team.is_owner ? (
+      {team.is_owner && canInviteMore ? (
         <section className="rounded-2xl border border-white/10 p-6">
-          <h2 className="text-sm font-semibold text-white">Invite member</h2>
-          <form onSubmit={handleInvite} className="mt-3 flex flex-col gap-3 sm:flex-row">
-            <input
-              type="email"
-              required
-              value={inviteEmail}
-              onChange={(e) => setInviteEmail(e.target.value)}
-              placeholder="tech@company.com.au"
-              className="min-w-0 flex-1 rounded-lg border border-white/12 bg-black/30 px-3 py-2 text-sm text-white"
-            />
+          <h2 className="text-sm font-semibold text-white">Add team member</h2>
+          <p className="mt-1 text-xs text-white/45">
+            Enter their email, tick the courses they should access, then send. They only get
+            enrolment and email text for the courses you select.
+          </p>
+          <form onSubmit={handleInvite} className="mt-4 space-y-4">
+            <label className="block text-sm text-white/70">
+              Email
+              <input
+                type="email"
+                required
+                value={inviteEmail}
+                onChange={(e) => setInviteEmail(e.target.value)}
+                placeholder="tech@company.com.au"
+                className="mt-1 w-full rounded-lg border border-white/12 bg-black/30 px-3 py-2 text-sm text-white"
+              />
+            </label>
+            <fieldset className="space-y-2">
+              <legend className="text-sm font-medium text-white/70">Courses they can access</legend>
+              {coursesLoading ? (
+                <p className="text-xs text-white/40">Loading your courses…</p>
+              ) : assignableCourses.length === 0 ? (
+                <p className="text-xs text-amber-200/80">
+                  You have no enrolled courses to assign. Enrol in a course first, then return here.
+                </p>
+              ) : (
+                <ul className="max-h-48 space-y-2 overflow-y-auto rounded-lg border border-white/10 bg-black/20 p-3">
+                  {assignableCourses.map((c) => {
+                    const noSeats =
+                      c.is_team_purchase_course &&
+                      typeof c.seats_remaining === 'number' &&
+                      c.seats_remaining <= 0;
+                    return (
+                      <li key={c.slug}>
+                        <label
+                          className={`flex items-start gap-2.5 text-sm ${noSeats ? 'cursor-not-allowed opacity-50' : 'cursor-pointer text-white/85'}`}
+                        >
+                          <input
+                            type="checkbox"
+                            className="mt-0.5"
+                            disabled={noSeats}
+                            checked={selectedCourseSlugs.includes(c.slug)}
+                            onChange={() => toggleCourseSlug(c.slug)}
+                          />
+                          <span>
+                            {c.title}
+                            {c.is_team_purchase_course ? (
+                              <span className="ml-1 text-xs text-[#7ec5ff]">
+                                (team purchase
+                                {typeof c.seats_used === 'number' && typeof c.seat_limit === 'number'
+                                  ? ` · ${c.seats_used}/${c.seat_limit} seats`
+                                  : ''}
+                                {(c.team_purchase_count ?? 0) > 1
+                                  ? ` · ${c.team_purchase_count} purchases`
+                                  : ''}
+                                )
+                              </span>
+                            ) : null}
+                            {noSeats ? (
+                              <span className="ml-1 text-xs text-amber-200/80">— full</span>
+                            ) : null}
+                          </span>
+                        </label>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </fieldset>
             <button
               type="submit"
-              disabled={busy}
-              className="rounded-lg bg-[#2490ed] px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+              disabled={busy || assignableCourses.length === 0 || selectedCourseSlugs.length === 0}
+              className="w-full rounded-lg bg-[#2490ed] px-4 py-2.5 text-sm font-semibold text-white disabled:opacity-50 sm:w-auto"
             >
-              Send invite
+              Add &amp; send email
             </button>
           </form>
-          {inviteUrl ? (
-            <p className="mt-3 break-all text-xs text-emerald-300/90">
-              Invite link (share securely): {inviteUrl}
-            </p>
-          ) : null}
-          {team.pending_invites.length > 0 ? (
-            <ul className="mt-4 space-y-1 text-xs text-white/45">
-              {team.pending_invites.map((i) => (
-                <li key={i.id}>Pending: {i.email}</li>
-              ))}
-            </ul>
-          ) : null}
         </section>
+      ) : null}
+
+      {team.is_owner && !canInviteMore ? (
+        <p className="text-sm text-white/45">
+          {isCourseTeam
+            ? 'All seats are in use for your team-purchased courses.'
+            : 'All seats are in use.'}
+        </p>
       ) : null}
     </div>
   );

--- a/app/(public)/courses/[slug]/page.tsx
+++ b/app/(public)/courses/[slug]/page.tsx
@@ -9,6 +9,8 @@ import { CourseHubContext } from '@/components/lms/CourseHubContext';
 import { CourseSchema, BreadcrumbSchema } from '@/components/seo';
 import { getBackendOrigin, getPublicSiteUrl } from '@/lib/env/public-url';
 import { normalizePublicAssetUrl } from '@/lib/remote-image';
+import { resolveCecHoursLabelForSlug } from '@/lib/cec-display';
+import { resolveCecHours } from '@/lib/seed/cec-hours';
 import { getPublishedCourseDetailBySlugFromDatabase } from '@/lib/server/public-courses-list';
 import {
   inferDisciplineFromWpExport,
@@ -48,6 +50,13 @@ function resolveAssetUrl(url?: string | null): string | null {
 }
 
 function mapWpExportToCourseDetail(row: WpExportCourse): CourseDetail {
+  const cec = resolveCecHours({
+    cec_hours: row.cec_hours,
+    short_description: row.short_description,
+    description: row.description,
+    meta: row.meta,
+  });
+
   return {
     id: String(row.wp_id),
     slug: row.slug,
@@ -59,12 +68,17 @@ function mapWpExportToCourseDetail(row: WpExportCourse): CourseDetail {
     level: row.level ?? null,
     category: row.category ?? null,
     iicrc_discipline: row.iicrc_discipline ?? inferDisciplineFromWpExport(row) ?? null,
-    cec_hours: null,
+    cec_hours: resolveCecHoursLabelForSlug(row.slug, cec),
     duration_hours: null,
     thumbnail_url: resolveAssetUrl(row.thumbnail_url),
     module_count: null,
     instructor: null,
   };
+}
+
+function withCourseCecFallback(course: CourseDetail): CourseDetail {
+  const cec_hours = resolveCecHoursLabelForSlug(course.slug, course.cec_hours);
+  return cec_hours ? { ...course, cec_hours } : course;
 }
 
 async function getCourse(slug: string): Promise<CourseDetail | null> {
@@ -73,7 +87,7 @@ async function getCourse(slug: string): Promise<CourseDetail | null> {
   if (process.env.DATABASE_URL?.trim()) {
     try {
       const fromDb = await getPublishedCourseDetailBySlugFromDatabase(slug);
-      if (fromDb) return fromDb;
+      if (fromDb) return withCourseCecFallback(fromDb);
     } catch (e) {
       console.error('[courses/[slug]] Failed to load course from database', e);
     }
@@ -83,7 +97,7 @@ async function getCourse(slug: string): Promise<CourseDetail | null> {
   const exported = loadWpExportCourses();
   if (exported && exported.length > 0) {
     const match = exported.find((c) => (c.slug ?? '').trim().toLowerCase() === targetSlug);
-    if (match) return mapWpExportToCourseDetail(match);
+    if (match) return withCourseCecFallback(mapWpExportToCourseDetail(match));
   }
 
   const base = backendUrl.replace(/\/$/, '');
@@ -95,7 +109,8 @@ async function getCourse(slug: string): Promise<CourseDetail | null> {
     });
     if (res.status === 404) return null;
     if (!res.ok) return null;
-    return res.json();
+    const data = (await res.json()) as CourseDetail;
+    return withCourseCecFallback(data);
   } catch {
     return null;
   }

--- a/app/(public)/courses/[slug]/page.tsx
+++ b/app/(public)/courses/[slug]/page.tsx
@@ -77,8 +77,10 @@ function mapWpExportToCourseDetail(row: WpExportCourse): CourseDetail {
 }
 
 function withCourseCecFallback(course: CourseDetail): CourseDetail {
-  const cec_hours = resolveCecHoursLabelForSlug(course.slug, course.cec_hours);
-  return cec_hours ? { ...course, cec_hours } : course;
+  return {
+    ...course,
+    cec_hours: resolveCecHoursLabelForSlug(course.slug, course.cec_hours),
+  };
 }
 
 async function getCourse(slug: string): Promise<CourseDetail | null> {

--- a/app/(public)/courses/[slug]/payment-success/PaymentSuccessClient.tsx
+++ b/app/(public)/courses/[slug]/payment-success/PaymentSuccessClient.tsx
@@ -28,11 +28,28 @@ export function PaymentSuccessClient() {
   const [learnUrl, setLearnUrl] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
-  const nextRaw = searchParams.get('next') ?? '/dashboard/student';
-  const nextPath = isSafeInternalPath(nextRaw) ? nextRaw : '/dashboard/student';
+  const isTeamPurchase = searchParams.get('purchase') === 'team';
+  const teamSeatsParam = searchParams.get('seats');
+  const teamCourseParam = searchParams.get('course') ?? slug;
   const sessionId = searchParams.get('session_id');
 
+  const teamNextPath =
+    sessionId && teamSeatsParam
+      ? `/dashboard/team?session_id=${encodeURIComponent(sessionId)}&from_purchase=1&course=${encodeURIComponent(teamCourseParam)}&seats=${encodeURIComponent(teamSeatsParam)}`
+      : null;
+
+  const nextRaw = searchParams.get('next') ?? teamNextPath ?? '/dashboard/student';
+  const nextPath = isSafeInternalPath(nextRaw) ? nextRaw : '/dashboard/student';
+
   useEffect(() => {
+    if (isTeamPurchase && teamNextPath) {
+      router.replace(teamNextPath);
+    }
+  }, [isTeamPurchase, teamNextPath, router]);
+
+  useEffect(() => {
+    if (isTeamPurchase) return;
+
     let cancelled = false;
 
     (async () => {
@@ -47,9 +64,10 @@ export function PaymentSuccessClient() {
           ...(sessionId ? { session_id: sessionId } : { slug }),
         });
         if (!cancelled) {
-          setLearnUrl(data.learn_url ?? nextPath);
+          const dest = data.learn_url ?? nextPath;
+          setLearnUrl(dest);
           setPhase('done');
-          router.push(data.learn_url ?? nextPath);
+          router.push(dest);
         }
         return;
       } catch {
@@ -67,7 +85,13 @@ export function PaymentSuccessClient() {
       try {
         const info = await fetch(
           `/api/lms/checkout/session?session_id=${encodeURIComponent(sessionId)}`,
-        ).then((r) => r.json() as Promise<{ email?: string; guest_checkout?: boolean }>);
+        ).then(
+          (r) =>
+            r.json() as Promise<{
+              email?: string;
+              guest_checkout?: boolean;
+            }>,
+        );
         if (!cancelled && info.email) {
           setSessionEmail(info.email);
           const stored = sessionStorage.getItem('carsi_guest_checkout');
@@ -95,7 +119,7 @@ export function PaymentSuccessClient() {
     return () => {
       cancelled = true;
     };
-  }, [router, nextPath, sessionId, slug]);
+  }, [router, nextPath, sessionId, slug, isTeamPurchase]);
 
   async function handleGuestComplete(e: React.FormEvent) {
     e.preventDefault();
@@ -129,6 +153,18 @@ export function PaymentSuccessClient() {
     }
   }
 
+  if (isTeamPurchase) {
+    return (
+      <main className="flex min-h-[60vh] items-center justify-center px-4">
+        <Card className="w-full max-w-md border-[0.5px] border-white/6 bg-[#050505]">
+          <CardContent className="p-8 text-center">
+            <p className="text-white/60">Taking you to your team dashboard…</p>
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
+
   if (phase === 'guest_setup') {
     return (
       <main className="flex min-h-[60vh] items-center justify-center px-4">
@@ -136,8 +172,8 @@ export function PaymentSuccessClient() {
           <CardContent className="space-y-4 p-8">
             <h1 className="text-2xl font-bold text-white">Payment successful</h1>
             <p className="text-sm text-white/60">
-              Create your password for <strong className="text-white/80">{sessionEmail}</strong> to
-              access your course.
+              Create your password for{' '}
+              <strong className="text-white/80">{sessionEmail}</strong> to access your course.
             </p>
             <form onSubmit={handleGuestComplete} className="space-y-3">
               <div className="space-y-1.5">

--- a/app/(public)/courses/[slug]/payment-success/PaymentSuccessClient.tsx
+++ b/app/(public)/courses/[slug]/payment-success/PaymentSuccessClient.tsx
@@ -153,7 +153,7 @@ export function PaymentSuccessClient() {
     }
   }
 
-  if (isTeamPurchase) {
+  if (isTeamPurchase && teamNextPath) {
     return (
       <main className="flex min-h-[60vh] items-center justify-center px-4">
         <Card className="w-full max-w-md border-[0.5px] border-white/6 bg-[#050505]">

--- a/app/api/admin/enrollments/complete/route.ts
+++ b/app/api/admin/enrollments/complete/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { adminMarkEnrollmentsComplete } from '@/lib/admin/admin-enrollment-mutations';
+import { getAdminSessionOrNull } from '@/lib/admin/admin-session';
+
+export async function POST(request: NextRequest) {
+  const session = await getAdminSessionOrNull();
+  if (!session) {
+    return NextResponse.json({ detail: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    studentId?: string;
+    enrollmentIds?: unknown;
+  };
+
+  const studentId = typeof body.studentId === 'string' ? body.studentId.trim() : '';
+  const rawIds = body.enrollmentIds;
+  const enrollmentIds = Array.isArray(rawIds)
+    ? rawIds.filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
+    : [];
+
+  if (!studentId || enrollmentIds.length === 0) {
+    return NextResponse.json(
+      { detail: 'studentId and at least one enrollmentId are required' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await adminMarkEnrollmentsComplete({ studentId, enrollmentIds });
+    return NextResponse.json({ ok: true, ...result });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg === 'USER_NOT_FOUND') {
+      return NextResponse.json({ detail: 'User not found' }, { status: 404 });
+    }
+    if (msg === 'NO_ENROLLMENTS') {
+      return NextResponse.json({ detail: 'No enrollments specified' }, { status: 400 });
+    }
+    if (msg === 'ENROLLMENT_NOT_FOUND') {
+      return NextResponse.json(
+        { detail: 'One or more enrollments were not found for this learner' },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({ detail: 'Failed to mark courses complete' }, { status: 500 });
+  }
+}

--- a/app/api/admin/enrollments/route.ts
+++ b/app/api/admin/enrollments/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { getAdminSessionOrNull } from '@/lib/admin/admin-session';
-import { adminGrantEnrollment } from '@/lib/admin/admin-enrollment-mutations';
+import { adminGrantEnrollment, adminGrantEnrollments } from '@/lib/admin/admin-enrollment-mutations';
 
 export async function POST(request: NextRequest) {
   const session = await getAdminSessionOrNull();
@@ -12,25 +12,48 @@ export async function POST(request: NextRequest) {
   const body = (await request.json().catch(() => ({}))) as {
     studentId?: string;
     courseSlug?: string;
+    courseSlugs?: unknown;
   };
 
   const studentId = typeof body.studentId === 'string' ? body.studentId.trim() : '';
   const courseSlug = typeof body.courseSlug === 'string' ? body.courseSlug.trim() : '';
-  if (!studentId || !courseSlug) {
-    return NextResponse.json({ detail: 'studentId and courseSlug are required' }, { status: 400 });
+  const courseSlugs = Array.isArray(body.courseSlugs)
+    ? body.courseSlugs.filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
+    : courseSlug
+      ? [courseSlug]
+      : [];
+
+  if (!studentId || courseSlugs.length === 0) {
+    return NextResponse.json(
+      { detail: 'studentId and at least one courseSlug (or courseSlugs) are required' },
+      { status: 400 },
+    );
   }
 
   try {
-    const result = await adminGrantEnrollment({ studentId, courseSlug });
-    if (result.kind === 'already_enrolled') {
-      return NextResponse.json({ ok: true, alreadyEnrolled: true, enrollmentId: result.enrollmentId });
+    if (courseSlugs.length === 1) {
+      const result = await adminGrantEnrollment({ studentId, courseSlug: courseSlugs[0]! });
+      if (result.kind === 'already_enrolled') {
+        return NextResponse.json({ ok: true, alreadyEnrolled: 1, created: 0, enrollmentIds: [result.enrollmentId] });
+      }
+      return NextResponse.json({
+        ok: true,
+        alreadyEnrolled: 0,
+        created: 1,
+        enrollmentIds: [result.enrollmentId],
+      });
     }
-    return NextResponse.json({ ok: true, alreadyEnrolled: false, enrollmentId: result.enrollmentId });
+
+    const result = await adminGrantEnrollments({ studentId, courseSlugs });
+    return NextResponse.json({ ok: true, ...result });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     if (msg === 'USER_NOT_FOUND') return NextResponse.json({ detail: 'User not found' }, { status: 404 });
-    if (msg === 'WORKBOOK_COURSE_NOT_FOUND') {
-      return NextResponse.json({ detail: 'Course not in workbook catalog' }, { status: 400 });
+    if (msg === 'NO_COURSES' || msg === 'INVALID_COURSE_SLUG') {
+      return NextResponse.json({ detail: 'Invalid course selection' }, { status: 400 });
+    }
+    if (msg === 'WORKBOOK_COURSE_NOT_FOUND' || msg === 'COURSE_NOT_FOUND') {
+      return NextResponse.json({ detail: 'Course not found in catalog' }, { status: 400 });
     }
     return NextResponse.json({ detail: 'Failed to grant enrollment' }, { status: 500 });
   }

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { getPostLoginRedirectPath } from '@/lib/admin/admin-auth';
 import { signSessionToken } from '@/lib/auth/session-jwt';
 import { authenticateWithPassword } from '@/lib/server/lms-auth';
 
@@ -7,9 +8,17 @@ const COOKIE_MAX_AGE = 60 * 60 * 24 * 7; // 7 days
 
 export async function POST(request: NextRequest) {
   try {
-    const body = (await request.json()) as { email?: unknown; password?: unknown };
+    const body = (await request.json()) as {
+      email?: unknown;
+      password?: unknown;
+      next?: unknown;
+      redirect?: unknown;
+    };
     const email = typeof body.email === 'string' ? body.email.trim() : '';
     const password = typeof body.password === 'string' ? body.password : '';
+    const requestedNext =
+      (typeof body.next === 'string' ? body.next : null) ??
+      (typeof body.redirect === 'string' ? body.redirect : null);
 
     if (!email || !password) {
       return NextResponse.json({ error: 'Email and password are required' }, { status: 400 });
@@ -31,6 +40,7 @@ export async function POST(request: NextRequest) {
 
     const response = NextResponse.json({
       success: true,
+      redirect_to: getPostLoginRedirectPath(claims, requestedNext),
       user: {
         id: claims.sub,
         email: claims.email,

--- a/app/api/lms/checkout/route.ts
+++ b/app/api/lms/checkout/route.ts
@@ -11,6 +11,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import { verifySessionToken } from '@/lib/auth/session-jwt';
 import { buildCourseCheckoutUrls } from '@/lib/checkout-urls';
 import {
+  parsePurchaseMode,
+  parseTeamSeatCount,
+  validateTeamSeatCount,
+} from '@/lib/checkout-purchase-mode';
+import {
   createStripeCheckoutForCourse,
   findCourseInExport,
   resolveCheckoutEmail,
@@ -34,6 +39,8 @@ export async function POST(request: NextRequest) {
       customer_email?: string;
       guest_checkout?: boolean;
       full_name?: string;
+      purchase_mode?: string;
+      team_seat_count?: number;
     };
 
     const slug = typeof body.slug === 'string' ? body.slug.trim() : '';
@@ -42,9 +49,14 @@ export async function POST(request: NextRequest) {
     }
 
     const normalized = slug.toLowerCase();
+    const purchaseMode = parsePurchaseMode(body.purchase_mode);
+    const teamSeatCount = parseTeamSeatCount(body.team_seat_count);
+
     const origin = request.nextUrl.origin;
     const learnNext = await getFirstLessonLearnPath(normalized);
-    const defaults = buildCourseCheckoutUrls(origin, slug, learnNext);
+    const defaults = buildCourseCheckoutUrls(origin, slug, learnNext, {
+      teamSeats: purchaseMode === 'team' ? teamSeatCount ?? undefined : undefined,
+    });
     const success_url =
       typeof body.success_url === 'string' && body.success_url.startsWith('http')
         ? body.success_url
@@ -70,6 +82,17 @@ export async function POST(request: NextRequest) {
     }
 
     const guestCheckout = body.guest_checkout === true;
+    const checkoutQuantity = purchaseMode === 'team' && teamSeatCount ? teamSeatCount : 1;
+
+    if (purchaseMode === 'team') {
+      if (!teamSeatCount) {
+        return NextResponse.json({ detail: 'team_seat_count is required for team purchases' }, { status: 400 });
+      }
+      const seatErr = validateTeamSeatCount(teamSeatCount);
+      if (seatErr) {
+        return NextResponse.json({ detail: seatErr }, { status: 400 });
+      }
+    }
 
     if (!customerEmail) {
       return NextResponse.json(
@@ -140,6 +163,9 @@ export async function POST(request: NextRequest) {
             unit_amount_cents: cents,
             extra_metadata: { discount_id: disc.id },
             guest_checkout: guestCheckout && !studentId,
+            quantity: checkoutQuantity,
+            purchase_mode: purchaseMode,
+            team_seat_count: teamSeatCount ?? undefined,
           });
           return NextResponse.json({ checkout_url });
         } catch (err) {
@@ -180,6 +206,9 @@ export async function POST(request: NextRequest) {
         student_id: studentId,
         unit_amount_cents,
         guest_checkout: guestCheckout && !studentId,
+        quantity: checkoutQuantity,
+        purchase_mode: purchaseMode,
+        team_seat_count: teamSeatCount ?? undefined,
       });
       return NextResponse.json({ checkout_url });
     } catch (err) {

--- a/app/api/lms/checkout/route.ts
+++ b/app/api/lms/checkout/route.ts
@@ -131,7 +131,7 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    if (studentId && dbCourse) {
+    if (studentId && dbCourse && purchaseMode !== 'team') {
       const disc = await findActiveUserDiscount(studentId, dbCourse.id);
       if (disc) {
         const finalAud = computeDiscountedAud(listAud, disc);
@@ -182,7 +182,7 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    if (isFreeCatalog) {
+    if (isFreeCatalog && purchaseMode !== 'team') {
       return NextResponse.json({ enrolled: true });
     }
 

--- a/app/api/lms/checkout/session/route.ts
+++ b/app/api/lms/checkout/session/route.ts
@@ -26,6 +26,10 @@ export async function GET(request: NextRequest) {
       email: email.trim().toLowerCase(),
       course_slug: slug,
       guest_checkout: session.metadata?.guest_checkout === 'true',
+      purchase_mode: session.metadata?.purchase_mode === 'team' ? 'team' : 'self',
+      team_seat_count: session.metadata?.team_seat_count
+        ? Number.parseInt(session.metadata.team_seat_count, 10)
+        : undefined,
     });
   } catch {
     return NextResponse.json({ detail: 'Invalid session' }, { status: 400 });

--- a/app/api/lms/enrollments/confirm/route.ts
+++ b/app/api/lms/enrollments/confirm/route.ts
@@ -4,8 +4,7 @@ import { getStripeClient } from '@/lib/api/stripe';
 import { getSessionClaimsFromRequest } from '@/lib/server/auth-from-request';
 import { notifyCrmEnrollmentCreated } from '@/lib/server/crm-enrollment-notify';
 import { sendEnrollmentWelcomeEmail } from '@/lib/server/enrollment-email';
-import { enrollStudentInCourse } from '@/lib/server/enrollment-service';
-import { getFirstLessonLearnPath } from '@/lib/server/first-lesson';
+import { fulfillCourseCheckoutForUser } from '@/lib/server/team-course-purchase';
 import { findCourseInExport } from '@/lib/server/local-course-checkout';
 import { computeDiscountedAud, findActiveUserDiscount } from '@/lib/server/user-discounts';
 import { getOrCreateCourseBySlug } from '@/lib/server/course-catalog-sync';
@@ -33,6 +32,8 @@ export async function POST(request: NextRequest) {
   const sessionId = typeof json.session_id === 'string' ? json.session_id.trim() : '';
 
   let paymentReference: string;
+  let purchaseMode: 'self' | 'team' = 'self';
+  let teamSeatCount: number | undefined;
 
   if (sessionId) {
     if (!process.env.STRIPE_SECRET_KEY?.trim()) {
@@ -49,6 +50,12 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ detail: 'Missing course on session' }, { status: 400 });
       }
       slug = metaSlug;
+      purchaseMode = session.metadata?.purchase_mode === 'team' ? 'team' : 'self';
+      const seatsMeta = session.metadata?.team_seat_count;
+      if (seatsMeta) {
+        const n = Number.parseInt(seatsMeta, 10);
+        if (Number.isFinite(n)) teamSeatCount = n;
+      }
       const email = session.customer_email ?? session.customer_details?.email;
       if (
         email &&
@@ -106,34 +113,44 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const result = await enrollStudentInCourse(claims, slug, paymentReference);
-    const learnUrl = (await getFirstLessonLearnPath(slug)) ?? '/dashboard/student';
-    if (result === 'already_enrolled') {
-      return NextResponse.json({ ok: true, already_enrolled: true, learn_url: learnUrl });
-    }
-
-    void sendEnrollmentWelcomeEmail({
-      studentId: claims.sub,
+    const fulfilled = await fulfillCourseCheckoutForUser({
+      claims,
       courseSlug: slug,
-      appOrigin: request.nextUrl.origin,
-    }).catch((e) => console.error('[enrollments/confirm] email', e));
-
-    notifyCrmEnrollmentCreated({
-      enrollmentId: result.enrollmentId,
-      studentId: claims.sub,
-      courseId: result.courseId,
+      paymentReference,
+      purchaseMode,
+      teamSeatCount,
     });
+
+    if (!fulfilled.alreadyEnrolled && fulfilled.enrollmentId && fulfilled.courseId) {
+      void sendEnrollmentWelcomeEmail({
+        studentId: claims.sub,
+        courseSlug: slug,
+        appOrigin: request.nextUrl.origin,
+      }).catch((e) => console.error('[enrollments/confirm] email', e));
+
+      notifyCrmEnrollmentCreated({
+        enrollmentId: fulfilled.enrollmentId,
+        studentId: claims.sub,
+        courseId: fulfilled.courseId,
+      });
+    }
 
     return NextResponse.json({
       ok: true,
-      enrollment_id: result.enrollmentId,
-      course_id: result.courseId,
-      learn_url: learnUrl,
+      already_enrolled: fulfilled.alreadyEnrolled,
+      learn_url: fulfilled.redirectPath,
+      team_purchase: fulfilled.kind === 'team',
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     if (msg === 'COURSE_NOT_FOUND') {
       return NextResponse.json({ detail: 'Course not found' }, { status: 404 });
+    }
+    if (msg === 'ALREADY_ON_TEAM') {
+      return NextResponse.json(
+        { detail: 'You already belong to another team. Contact support to move your purchase.' },
+        { status: 409 },
+      );
     }
     console.error('[enrollments/confirm]', e);
     return NextResponse.json({ detail: 'Enrolment failed' }, { status: 500 });

--- a/app/api/lms/enrollments/guest-complete/route.ts
+++ b/app/api/lms/enrollments/guest-complete/route.ts
@@ -4,9 +4,10 @@ import { signSessionToken } from '@/lib/auth/session-jwt';
 import { getStripeClient } from '@/lib/api/stripe';
 import { notifyCrmEnrollmentCreated } from '@/lib/server/crm-enrollment-notify';
 import { sendEnrollmentWelcomeEmail } from '@/lib/server/enrollment-email';
-import { enrollStudentInCourse } from '@/lib/server/enrollment-service';
 import { findOrCreateGuestUser } from '@/lib/server/guest-checkout';
-import { getFirstLessonLearnPath } from '@/lib/server/first-lesson';
+import { getTeamForUser } from '@/lib/server/teams';
+import { fulfillCourseCheckoutForUser } from '@/lib/server/team-course-purchase';
+import { prisma } from '@/lib/prisma';
 
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 
@@ -23,6 +24,7 @@ export async function POST(request: NextRequest) {
     session_id?: string;
     password?: string;
     full_name?: string;
+    team_name?: string;
   };
 
   const sessionId = body.session_id?.trim();
@@ -66,12 +68,32 @@ export async function POST(request: NextRequest) {
       password,
     });
 
-    const result = await enrollStudentInCourse(claims, slug, sessionId);
-    const alreadyEnrolled = result === 'already_enrolled';
-    const origin = request.nextUrl.origin;
-    const learnPath = (await getFirstLessonLearnPath(slug)) ?? '/dashboard/student';
+    const purchaseMode = session.metadata?.purchase_mode === 'team' ? 'team' : 'self';
+    const seatsMeta = session.metadata?.team_seat_count;
+    const teamSeatCount = seatsMeta ? Number.parseInt(seatsMeta, 10) : undefined;
 
-    if (!alreadyEnrolled) {
+    const fulfilled = await fulfillCourseCheckoutForUser({
+      claims,
+      courseSlug: slug,
+      paymentReference: sessionId,
+      purchaseMode,
+      teamSeatCount: Number.isFinite(teamSeatCount) ? teamSeatCount : undefined,
+    });
+
+    const teamName = typeof body.team_name === 'string' ? body.team_name.trim() : '';
+    if (purchaseMode === 'team' && teamName.length >= 2) {
+      const ownedTeam = await getTeamForUser(claims.sub);
+      if (ownedTeam && ownedTeam.ownerId === claims.sub) {
+        await prisma.lmsTeam.update({
+          where: { id: ownedTeam.id },
+          data: { name: teamName.slice(0, 80) },
+        });
+      }
+    }
+
+    const origin = request.nextUrl.origin;
+
+    if (!fulfilled.alreadyEnrolled && fulfilled.enrollmentId && fulfilled.courseId) {
       void sendEnrollmentWelcomeEmail({
         studentId: claims.sub,
         courseSlug: slug,
@@ -79,17 +101,21 @@ export async function POST(request: NextRequest) {
       }).catch((e) => console.error('[guest-complete] email', e));
 
       notifyCrmEnrollmentCreated({
-        enrollmentId: result.enrollmentId,
+        enrollmentId: fulfilled.enrollmentId,
         studentId: claims.sub,
-        courseId: result.courseId,
+        courseId: fulfilled.courseId,
       });
     }
 
     const accessToken = await signSessionToken(claims);
     const response = NextResponse.json({
       ok: true,
-      learn_url: learnPath,
-      already_enrolled: alreadyEnrolled,
+      learn_url:
+        fulfilled.kind === 'team'
+          ? `/dashboard/team?from_purchase=1&course=${encodeURIComponent(slug)}${Number.isFinite(teamSeatCount) ? `&seats=${teamSeatCount}` : ''}`
+          : fulfilled.redirectPath,
+      team_purchase: fulfilled.kind === 'team',
+      already_enrolled: fulfilled.alreadyEnrolled,
     });
 
     const cookieOptions = {
@@ -103,6 +129,13 @@ export async function POST(request: NextRequest) {
 
     return response;
   } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg === 'ALREADY_ON_TEAM') {
+      return NextResponse.json(
+        { detail: 'You already belong to another team. Contact support@carsi.com.au' },
+        { status: 409 },
+      );
+    }
     console.error('[guest-complete]', e);
     return NextResponse.json({ detail: 'Could not complete enrolment' }, { status: 500 });
   }

--- a/app/api/lms/enrollments/me/route.ts
+++ b/app/api/lms/enrollments/me/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { verifySessionToken } from '@/lib/auth/session-jwt';
 import { getEnrollmentsForStudent } from '@/lib/server/learner-dashboard-data';
+import { nextResponseFromFetch } from '@/lib/server/proxy-fetch-response';
 import { getUpstreamBaseUrl } from '@/lib/server/upstream-api';
 
 /**
@@ -26,12 +27,7 @@ export async function GET(request: NextRequest) {
       headers: { authorization: auth, cookie: request.headers.get('cookie') ?? '' },
       cache: 'no-store',
     });
-    const contentType = res.headers.get('content-type') || 'application/json';
-    const buf = await res.arrayBuffer();
-    return new NextResponse(buf, {
-      status: res.status,
-      headers: { 'content-type': contentType },
-    });
+    return nextResponseFromFetch(res);
   }
 
   if (!process.env.DATABASE_URL?.trim()) {

--- a/app/api/lms/teams/activate-purchase/route.ts
+++ b/app/api/lms/teams/activate-purchase/route.ts
@@ -1,0 +1,120 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { getStripeClient } from '@/lib/api/stripe';
+import { prisma } from '@/lib/prisma';
+import { getSessionClaimsFromRequest } from '@/lib/server/auth-from-request';
+import { serializeTeamForClient } from '@/lib/server/team-api-serialize';
+import { fulfillCourseCheckoutForUser } from '@/lib/server/team-course-purchase';
+import { repairAndGetTeamForUser } from '@/lib/server/teams';
+
+async function findStripeCheckoutSessionForUser(userId: string): Promise<string | null> {
+  const enrollment = await prisma.lmsEnrollment.findFirst({
+    where: {
+      studentId: userId,
+      paymentReference: { startsWith: 'cs_' },
+    },
+    orderBy: { enrolledAt: 'desc' },
+    select: { paymentReference: true },
+  });
+  const ref = enrollment?.paymentReference?.trim();
+  return ref && ref.startsWith('cs_') ? ref : null;
+}
+
+/**
+ * POST /api/lms/teams/activate-purchase
+ * Ensures a course team purchase is provisioned (Stripe session) and returns the team.
+ */
+export async function POST(request: NextRequest) {
+  const claims = await getSessionClaimsFromRequest(request);
+  if (!claims) {
+    return NextResponse.json({ detail: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!process.env.DATABASE_URL?.trim()) {
+    return NextResponse.json({ detail: 'Database not configured' }, { status: 503 });
+  }
+
+  let body: { session_id?: string };
+  try {
+    body = await request.json().catch(() => ({}));
+  } catch {
+    body = {};
+  }
+
+  let sessionId = typeof body.session_id === 'string' ? body.session_id.trim() : '';
+
+  try {
+    let existing = await repairAndGetTeamForUser(claims.sub);
+
+    if (!sessionId) {
+      sessionId = (await findStripeCheckoutSessionForUser(claims.sub)) ?? '';
+    }
+
+    if (sessionId && process.env.STRIPE_SECRET_KEY?.trim()) {
+      const stripe = getStripeClient();
+      const session = await stripe.checkout.sessions.retrieve(sessionId);
+      if (session.payment_status !== 'paid') {
+        return NextResponse.json({ detail: 'Payment not completed' }, { status: 400 });
+      }
+
+      const purchaseMode = session.metadata?.purchase_mode === 'team' ? 'team' : 'self';
+      if (purchaseMode !== 'team') {
+        return NextResponse.json({ detail: 'Not a team purchase session' }, { status: 400 });
+      }
+
+      const email = (
+        session.customer_email ??
+        session.customer_details?.email ??
+        ''
+      )
+        .trim()
+        .toLowerCase();
+      if (email && claims.email && email !== claims.email.toLowerCase()) {
+        return NextResponse.json(
+          {
+            detail:
+              'This payment was made with a different email. Sign in with that email or contact support.',
+          },
+          { status: 403 },
+        );
+      }
+
+      const slug = session.metadata?.course_slug?.trim().toLowerCase();
+      const seatsMeta = session.metadata?.team_seat_count;
+      const teamSeatCount = seatsMeta ? Number.parseInt(seatsMeta, 10) : undefined;
+      if (!slug || !teamSeatCount || teamSeatCount < 2) {
+        return NextResponse.json({ detail: 'Invalid team checkout session' }, { status: 400 });
+      }
+
+      await fulfillCourseCheckoutForUser({
+        claims,
+        courseSlug: slug,
+        paymentReference: sessionId,
+        purchaseMode: 'team',
+        teamSeatCount,
+      });
+    }
+
+    existing = await repairAndGetTeamForUser(claims.sub);
+    if (!existing) {
+      return NextResponse.json({
+        team: null,
+        detail: 'No team found for this account yet. If you just paid, wait a moment and refresh.',
+      });
+    }
+
+    return NextResponse.json({
+      team: await serializeTeamForClient(existing, claims.sub),
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg === 'ALREADY_ON_TEAM') {
+      return NextResponse.json(
+        { detail: 'You already belong to another team as a member.' },
+        { status: 409 },
+      );
+    }
+    console.error('[teams/activate-purchase]', e);
+    return NextResponse.json({ detail: 'Failed to activate team purchase' }, { status: 500 });
+  }
+}

--- a/app/api/lms/teams/activate-purchase/route.ts
+++ b/app/api/lms/teams/activate-purchase/route.ts
@@ -7,17 +7,38 @@ import { serializeTeamForClient } from '@/lib/server/team-api-serialize';
 import { fulfillCourseCheckoutForUser } from '@/lib/server/team-course-purchase';
 import { repairAndGetTeamForUser } from '@/lib/server/teams';
 
-async function findStripeCheckoutSessionForUser(userId: string): Promise<string | null> {
-  const enrollment = await prisma.lmsEnrollment.findFirst({
+async function findTeamStripeCheckoutSessionForUser(userId: string): Promise<string | null> {
+  const enrollments = await prisma.lmsEnrollment.findMany({
     where: {
       studentId: userId,
       paymentReference: { startsWith: 'cs_' },
     },
     orderBy: { enrolledAt: 'desc' },
     select: { paymentReference: true },
+    take: 15,
   });
-  const ref = enrollment?.paymentReference?.trim();
-  return ref && ref.startsWith('cs_') ? ref : null;
+
+  if (!process.env.STRIPE_SECRET_KEY?.trim()) {
+    return null;
+  }
+
+  const stripe = getStripeClient();
+  for (const row of enrollments) {
+    const ref = row.paymentReference?.trim();
+    if (!ref?.startsWith('cs_')) continue;
+    try {
+      const session = await stripe.checkout.sessions.retrieve(ref);
+      if (
+        session.payment_status === 'paid' &&
+        session.metadata?.purchase_mode === 'team'
+      ) {
+        return ref;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
 }
 
 /**
@@ -49,7 +70,7 @@ export async function POST(request: NextRequest) {
     let existing = await repairAndGetTeamForUser(claims.sub);
 
     if (!sessionId) {
-      sessionId = (await findStripeCheckoutSessionForUser(claims.sub)) ?? '';
+      sessionId = (await findTeamStripeCheckoutSessionForUser(claims.sub)) ?? '';
     }
 
     if (sessionId && process.env.STRIPE_SECRET_KEY?.trim()) {

--- a/app/api/lms/teams/activate-purchase/route.ts
+++ b/app/api/lms/teams/activate-purchase/route.ts
@@ -41,7 +41,9 @@ export async function POST(request: NextRequest) {
     body = {};
   }
 
-  let sessionId = typeof body.session_id === 'string' ? body.session_id.trim() : '';
+  const explicitSessionId =
+    typeof body.session_id === 'string' && body.session_id.trim().length > 0;
+  let sessionId = explicitSessionId ? body.session_id!.trim() : '';
 
   try {
     let existing = await repairAndGetTeamForUser(claims.sub);
@@ -59,40 +61,42 @@ export async function POST(request: NextRequest) {
 
       const purchaseMode = session.metadata?.purchase_mode === 'team' ? 'team' : 'self';
       if (purchaseMode !== 'team') {
-        return NextResponse.json({ detail: 'Not a team purchase session' }, { status: 400 });
-      }
+        if (explicitSessionId) {
+          return NextResponse.json({ detail: 'Not a team purchase session' }, { status: 400 });
+        }
+      } else {
+        const email = (
+          session.customer_email ??
+          session.customer_details?.email ??
+          ''
+        )
+          .trim()
+          .toLowerCase();
+        if (email && claims.email && email !== claims.email.toLowerCase()) {
+          return NextResponse.json(
+            {
+              detail:
+                'This payment was made with a different email. Sign in with that email or contact support.',
+            },
+            { status: 403 },
+          );
+        }
 
-      const email = (
-        session.customer_email ??
-        session.customer_details?.email ??
-        ''
-      )
-        .trim()
-        .toLowerCase();
-      if (email && claims.email && email !== claims.email.toLowerCase()) {
-        return NextResponse.json(
-          {
-            detail:
-              'This payment was made with a different email. Sign in with that email or contact support.',
-          },
-          { status: 403 },
-        );
-      }
+        const slug = session.metadata?.course_slug?.trim().toLowerCase();
+        const seatsMeta = session.metadata?.team_seat_count;
+        const teamSeatCount = seatsMeta ? Number.parseInt(seatsMeta, 10) : undefined;
+        if (!slug || !teamSeatCount || teamSeatCount < 2) {
+          return NextResponse.json({ detail: 'Invalid team checkout session' }, { status: 400 });
+        }
 
-      const slug = session.metadata?.course_slug?.trim().toLowerCase();
-      const seatsMeta = session.metadata?.team_seat_count;
-      const teamSeatCount = seatsMeta ? Number.parseInt(seatsMeta, 10) : undefined;
-      if (!slug || !teamSeatCount || teamSeatCount < 2) {
-        return NextResponse.json({ detail: 'Invalid team checkout session' }, { status: 400 });
+        await fulfillCourseCheckoutForUser({
+          claims,
+          courseSlug: slug,
+          paymentReference: sessionId,
+          purchaseMode: 'team',
+          teamSeatCount,
+        });
       }
-
-      await fulfillCourseCheckoutForUser({
-        claims,
-        courseSlug: slug,
-        paymentReference: sessionId,
-        purchaseMode: 'team',
-        teamSeatCount,
-      });
     }
 
     existing = await repairAndGetTeamForUser(claims.sub);

--- a/app/api/lms/teams/assignable-courses/route.ts
+++ b/app/api/lms/teams/assignable-courses/route.ts
@@ -1,0 +1,72 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { prisma } from '@/lib/prisma';
+import { getSessionClaimsFromRequest } from '@/lib/server/auth-from-request';
+import { getTeamCourseSeatPools } from '@/lib/server/team-course-seats';
+import { repairAndGetTeamForUser } from '@/lib/server/teams';
+
+/** GET /api/lms/teams/assignable-courses — owner's enrolled courses for team invites. */
+export async function GET(request: NextRequest) {
+  const claims = await getSessionClaimsFromRequest(request);
+  if (!claims) {
+    return NextResponse.json({ detail: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!process.env.DATABASE_URL?.trim()) {
+    return NextResponse.json({ courses: [] });
+  }
+
+  try {
+    const team = await repairAndGetTeamForUser(claims.sub);
+    const pools = team ? await getTeamCourseSeatPools(team.id) : [];
+    const poolBySlug = new Map(pools.map((p) => [p.course_slug, p]));
+
+    const rows = await prisma.lmsEnrollment.findMany({
+      where: {
+        studentId: claims.sub,
+        status: { notIn: ['cancelled'] },
+        course: { isPublished: true },
+      },
+      include: {
+        course: { select: { slug: true, title: true } },
+      },
+      orderBy: { enrolledAt: 'desc' },
+    });
+
+    const seen = new Set<string>();
+    const courses: {
+      slug: string;
+      title: string;
+      is_team_purchase_course: boolean;
+      seat_limit?: number;
+      seats_used?: number;
+      seats_remaining?: number;
+      team_purchase_count?: number;
+    }[] = [];
+
+    for (const row of rows) {
+      const slug = row.course.slug.trim().toLowerCase();
+      if (!slug || seen.has(slug)) continue;
+      seen.add(slug);
+      const pool = poolBySlug.get(slug);
+      courses.push({
+        slug,
+        title: row.course.title,
+        is_team_purchase_course: Boolean(pool),
+        ...(pool
+          ? {
+              seat_limit: pool.seat_limit,
+              seats_used: pool.seats_used,
+              seats_remaining: pool.seats_remaining,
+              team_purchase_count: pool.purchase_count,
+            }
+          : {}),
+      });
+    }
+
+    return NextResponse.json({ courses, course_seat_pools: pools });
+  } catch (e) {
+    console.error('[teams/assignable-courses]', e);
+    return NextResponse.json({ detail: 'Failed to load courses' }, { status: 500 });
+  }
+}

--- a/app/api/lms/teams/invite/accept/route.ts
+++ b/app/api/lms/teams/invite/accept/route.ts
@@ -71,7 +71,11 @@ export async function POST(request: NextRequest) {
       }),
     ]);
 
-    await enrollTeamMemberInPurchasedCourse(claims.sub, invite.teamId);
+    try {
+      await enrollTeamMemberInPurchasedCourse(claims.sub, invite.teamId);
+    } catch (enrollErr) {
+      console.error('[teams/invite/accept] enrol', enrollErr);
+    }
 
     return NextResponse.json({
       team_id: invite.teamId,

--- a/app/api/lms/teams/invite/accept/route.ts
+++ b/app/api/lms/teams/invite/accept/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/prisma';
 import { getSessionClaimsFromRequest } from '@/lib/server/auth-from-request';
+import { enrollTeamMemberInPurchasedCourse } from '@/lib/server/team-course-purchase';
 import { countTeamSeatsUsed } from '@/lib/server/teams';
 
 /** POST /api/lms/teams/invite/accept — accept invite token. */
@@ -47,13 +48,6 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const existingMember = await prisma.lmsTeamMember.findFirst({
-      where: { userId: claims.sub },
-    });
-    if (existingMember && existingMember.teamId !== invite.teamId) {
-      return NextResponse.json({ detail: 'You already belong to another team' }, { status: 409 });
-    }
-
     const seatsUsed = await countTeamSeatsUsed(invite.teamId);
     if (seatsUsed >= invite.team.seatLimit) {
       return NextResponse.json({ detail: 'Team is full' }, { status: 409 });
@@ -76,6 +70,8 @@ export async function POST(request: NextRequest) {
         data: { acceptedAt: new Date() },
       }),
     ]);
+
+    await enrollTeamMemberInPurchasedCourse(claims.sub, invite.teamId);
 
     return NextResponse.json({
       team_id: invite.teamId,

--- a/app/api/lms/teams/invite/route.ts
+++ b/app/api/lms/teams/invite/route.ts
@@ -2,16 +2,17 @@ import { type NextRequest, NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/prisma';
 import { getSessionClaimsFromRequest } from '@/lib/server/auth-from-request';
-import { countTeamSeatsUsed, generateInviteToken, getTeamForUser } from '@/lib/server/teams';
+import { addCourseTeamMemberByEmail } from '@/lib/server/team-member-provision';
+import { countTeamSeatsUsed, generateInviteToken, repairAndGetTeamForUser } from '@/lib/server/teams';
 
-/** POST /api/lms/teams/invite — owner/admin invites a member by email. */
+/** POST /api/lms/teams/invite — owner/admin adds a member by email with selected courses. */
 export async function POST(request: NextRequest) {
   const claims = await getSessionClaimsFromRequest(request);
   if (!claims) {
     return NextResponse.json({ detail: 'Unauthorized' }, { status: 401 });
   }
 
-  let body: { email?: string; role?: string };
+  let body: { email?: string; role?: string; course_slugs?: string[] };
   try {
     body = await request.json();
   } catch {
@@ -20,12 +21,16 @@ export async function POST(request: NextRequest) {
 
   const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
   const role = body.role === 'admin' ? 'admin' : 'member';
+  const courseSlugs = Array.isArray(body.course_slugs)
+    ? body.course_slugs.filter((s): s is string => typeof s === 'string')
+    : [];
+
   if (!email || !email.includes('@')) {
     return NextResponse.json({ detail: 'Valid email required' }, { status: 400 });
   }
 
   try {
-    const team = await getTeamForUser(claims.sub);
+    const team = await repairAndGetTeamForUser(claims.sub);
     if (!team) {
       return NextResponse.json({ detail: 'No team found' }, { status: 404 });
     }
@@ -33,6 +38,35 @@ export async function POST(request: NextRequest) {
     const membership = team.members.find((m) => m.userId === claims.sub);
     if (!membership || !['owner', 'admin'].includes(membership.role)) {
       return NextResponse.json({ detail: 'Forbidden' }, { status: 403 });
+    }
+
+    if (courseSlugs.length > 0) {
+      const owner = await prisma.lmsUser.findUnique({
+        where: { id: claims.sub },
+        select: { fullName: true, email: true },
+      });
+      const inviterName =
+        owner?.fullName?.trim() || owner?.email?.split('@')[0] || 'Your team owner';
+
+      const result = await addCourseTeamMemberByEmail({
+        ownerId: claims.sub,
+        inviterName,
+        email,
+        appOrigin: request.nextUrl.origin,
+        courseSlugs,
+      });
+
+      const courseLabel =
+        result.courses.length === 1
+          ? result.courses[0]
+          : `${result.courses.length} courses`;
+
+      return NextResponse.json({
+        email: result.email,
+        account_created: result.account_created,
+        courses: result.courses,
+        message: `Added ${result.email}. Email sent with access to ${courseLabel} only.`,
+      });
     }
 
     const seatsUsed = await countTeamSeatsUsed(team.id);
@@ -67,7 +101,32 @@ export async function POST(request: NextRequest) {
       expires_at: invite.expiresAt.toISOString(),
     });
   } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg === 'TEAM_FULL' || msg === 'COURSE_SEATS_FULL') {
+      return NextResponse.json(
+        { detail: 'No seats left for one or more selected courses' },
+        { status: 409 },
+      );
+    }
+    if (msg === 'NO_SEATS_FOR_COURSE') {
+      return NextResponse.json(
+        { detail: 'Selected course is not on your team seat plan' },
+        { status: 403 },
+      );
+    }
+    if (msg === 'ALREADY_MEMBER') {
+      return NextResponse.json({ detail: 'This person is already on your team' }, { status: 409 });
+    }
+    if (msg === 'NO_COURSES_SELECTED') {
+      return NextResponse.json({ detail: 'Select at least one course' }, { status: 400 });
+    }
+    if (msg === 'OWNER_NOT_ENROLLED') {
+      return NextResponse.json(
+        { detail: 'You can only assign courses you are enrolled in' },
+        { status: 403 },
+      );
+    }
     console.error('[teams/invite]', e);
-    return NextResponse.json({ detail: 'Failed to create invite' }, { status: 500 });
+    return NextResponse.json({ detail: 'Failed to add team member' }, { status: 500 });
   }
 }

--- a/app/api/lms/teams/invite/route.ts
+++ b/app/api/lms/teams/invite/route.ts
@@ -114,6 +114,12 @@ export async function POST(request: NextRequest) {
         { status: 403 },
       );
     }
+    if (msg === 'NOT_TEAM_PURCHASE_COURSE') {
+      return NextResponse.json(
+        { detail: 'Only team-purchased courses can be assigned on a course team plan' },
+        { status: 403 },
+      );
+    }
     if (msg === 'ALREADY_MEMBER') {
       return NextResponse.json({ detail: 'This person is already on your team' }, { status: 409 });
     }

--- a/app/api/lms/teams/me/route.ts
+++ b/app/api/lms/teams/me/route.ts
@@ -1,7 +1,9 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
+import { prisma } from '@/lib/prisma';
 import { getSessionClaimsFromRequest } from '@/lib/server/auth-from-request';
-import { countTeamSeatsUsed, getTeamForUser } from '@/lib/server/teams';
+import { serializeTeamForClient } from '@/lib/server/team-api-serialize';
+import { repairAndGetTeamForUser } from '@/lib/server/teams';
 
 /** GET /api/lms/teams/me — current user's team membership. */
 export async function GET(request: NextRequest) {
@@ -15,39 +17,54 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const team = await getTeamForUser(claims.sub);
+    const team = await repairAndGetTeamForUser(claims.sub);
     if (!team) {
       return NextResponse.json({ team: null });
     }
 
-    const seatsUsed = await countTeamSeatsUsed(team.id);
-
     return NextResponse.json({
-      team: {
-        id: team.id,
-        name: team.name,
-        slug: team.slug,
-        bundle_tier: team.bundleTier,
-        seat_limit: team.seatLimit,
-        seats_used: seatsUsed,
-        owner_id: team.ownerId,
-        is_owner: team.ownerId === claims.sub,
-        members: team.members.map((m) => ({
-          user_id: m.userId,
-          role: m.role,
-          email: m.user.email,
-          full_name: m.user.fullName,
-        })),
-        pending_invites: team.invites.map((i) => ({
-          id: i.id,
-          email: i.email,
-          role: i.role,
-          expires_at: i.expiresAt.toISOString(),
-        })),
-      },
+      team: await serializeTeamForClient(team, claims.sub),
     });
   } catch (e) {
     console.error('[teams/me]', e);
     return NextResponse.json({ detail: 'Failed to load team' }, { status: 500 });
+  }
+}
+
+/** PATCH /api/lms/teams/me — update team name (owner only). */
+export async function PATCH(request: NextRequest) {
+  const claims = await getSessionClaimsFromRequest(request);
+  if (!claims) {
+    return NextResponse.json({ detail: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: { name?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ detail: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  if (name.length < 2) {
+    return NextResponse.json({ detail: 'Team name must be at least 2 characters' }, { status: 400 });
+  }
+
+  try {
+    const team = await repairAndGetTeamForUser(claims.sub);
+    if (!team || team.ownerId !== claims.sub) {
+      return NextResponse.json({ detail: 'Forbidden' }, { status: 403 });
+    }
+
+    const updated = await prisma.lmsTeam.update({
+      where: { id: team.id },
+      data: { name: name.slice(0, 80) },
+      select: { name: true },
+    });
+
+    return NextResponse.json({ name: updated.name });
+  } catch (e) {
+    console.error('[teams/me PATCH]', e);
+    return NextResponse.json({ detail: 'Failed to update team' }, { status: 500 });
   }
 }

--- a/app/api/lms/webhooks/stripe/route.ts
+++ b/app/api/lms/webhooks/stripe/route.ts
@@ -11,10 +11,10 @@ import { constructWebhookEvent } from '@/lib/api/stripe';
 import { getAppOrigin } from '@/lib/server/app-url';
 import { notifyCrmEnrollmentCreated } from '@/lib/server/crm-enrollment-notify';
 import { sendEnrollmentWelcomeEmail } from '@/lib/server/enrollment-email';
-import { enrollStudentInCourse } from '@/lib/server/enrollment-service';
 import { ensureGuestUserFromStripeEmail } from '@/lib/server/guest-checkout';
 import { sessionClaimsForUserId } from '@/lib/server/lms-auth';
 import { prisma } from '@/lib/prisma';
+import { fulfillCourseCheckoutForUser } from '@/lib/server/team-course-purchase';
 
 export async function POST(request: NextRequest) {
   const rawBody = await request.text();
@@ -76,24 +76,40 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ received: true });
   }
 
+  const purchaseMode = session.metadata?.purchase_mode === 'team' ? 'team' : 'self';
+  const teamSeatRaw = session.metadata?.team_seat_count;
+  const teamSeatCount = teamSeatRaw ? Number.parseInt(teamSeatRaw, 10) : undefined;
+
   try {
     const ref = typeof session.id === 'string' ? session.id : 'stripe_webhook';
-    const result = await enrollStudentInCourse(claims, slug, ref);
-    if (result !== 'already_enrolled') {
-      const origin = getAppOrigin();
+    const origin = getAppOrigin();
+    const fulfilled = await fulfillCourseCheckoutForUser({
+      claims,
+      courseSlug: slug,
+      paymentReference: ref,
+      purchaseMode,
+      teamSeatCount: Number.isFinite(teamSeatCount) ? teamSeatCount : undefined,
+    });
+
+    if (!fulfilled.alreadyEnrolled && fulfilled.enrollmentId && fulfilled.courseId) {
       void sendEnrollmentWelcomeEmail({
         studentId: claims.sub,
         courseSlug: slug,
         appOrigin: origin,
       }).catch((e) => console.error('[stripe webhook] email', e));
       notifyCrmEnrollmentCreated({
-        enrollmentId: result.enrollmentId,
+        enrollmentId: fulfilled.enrollmentId,
         studentId: claims.sub,
-        courseId: result.courseId,
+        courseId: fulfilled.courseId,
       });
     }
   } catch (e) {
-    console.error('[stripe webhook] enrolment error:', e);
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg === 'ALREADY_ON_TEAM') {
+      console.warn('[stripe webhook] team purchase blocked: user on another team');
+    } else {
+      console.error('[stripe webhook] enrolment error:', e);
+    }
   }
 
   return NextResponse.json({ received: true });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from 'next';
 import {
   AnimatedCard,
   AnimatedHero,
@@ -24,6 +23,7 @@ import {
 } from '@/lib/server/public-catalogue-facts';
 import { getHomepageFeaturedCourses } from '@/lib/server/public-courses-list';
 import type { CourseListItem } from '@/lib/wordpress-export-courses';
+import type { LucideIcon } from 'lucide-react';
 import {
   ArrowRight,
   Award,
@@ -47,7 +47,7 @@ import {
   Sparkles,
   Users,
 } from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 
 /** Always render homepage on the server so featured courses load from `DATABASE_URL` at request time (not a static build snapshot). */
@@ -158,47 +158,40 @@ const onlineHighlights = [
   },
 ] as const;
 
-function buildHomeFaqs(facts: {
-  publishedCourseCount: number;
-  disciplineCodes: string[];
-}) {
+function buildHomeFaqs(facts: { publishedCourseCount: number; disciplineCodes: string[] }) {
   const n = facts.publishedCourseCount;
   const d = facts.disciplineCodes.length;
   const coursePhrase =
-    n > 0
-      ? `${n} published course${n === 1 ? '' : 's'}`
-      : 'IICRC CEC-approved courses';
+    n > 0 ? `${n} published course${n === 1 ? '' : 's'}` : 'IICRC CEC-approved courses';
   const discPhrase =
-    d > 0
-      ? `${d} IICRC discipline${d === 1 ? '' : 's'}`
-      : 'the core IICRC disciplines';
+    d > 0 ? `${d} IICRC discipline${d === 1 ? '' : 's'}` : 'the core IICRC disciplines';
 
   return [
-  {
-    question: 'What is CARSI?',
-    answer: `CARSI is an Australian online training platform offering IICRC CEC-approved courses for cleaning and restoration professionals. With ${coursePhrase} across ${discPhrase}, CARSI enables technicians to maintain their certification entirely online.`,
-  },
-  {
-    question: 'How do IICRC CECs work?',
-    answer:
-      'IICRC Continuing Education Credits (CECs) are required every two years to maintain certified technician status. Each CARSI course awards a specific number of CECs upon completion. Credits are tracked automatically in your student dashboard and can be reported to the IICRC for renewal.',
-  },
-  {
-    question: 'Is CARSI training recognised by insurers?',
-    answer:
-      'CARSI courses are IICRC CEC-approved, and IICRC certification is recognised by major Australian insurers including IAG, Suncorp, and QBE as evidence of professional competency. CARSI is also a core pillar of the NRPG onboarding pathway.',
-  },
-  {
-    question: 'Can I complete training at my own pace?',
-    answer:
-      'Yes. All CARSI courses are available 24/7 and fully self-paced. You can pause mid-lesson, resume between jobs, and fit study around shift work or on-call rosters. There are no deadlines or scheduled class times.',
-  },
-  {
-    question: 'What industries does CARSI serve?',
-    answer:
-      'CARSI serves over 12 industries including healthcare, hospitality, aged care, mining and resources, commercial cleaning, government and defence, education, property management, strata, retail, childcare, and construction.',
-  },
-];
+    {
+      question: 'What is CARSI?',
+      answer: `CARSI is an Australian online training platform offering IICRC CEC-approved courses for cleaning and restoration professionals. With ${coursePhrase} across ${discPhrase}, CARSI enables technicians to maintain their certification entirely online.`,
+    },
+    {
+      question: 'How do IICRC CECs work?',
+      answer:
+        'IICRC Continuing Education Credits (CECs) are required every two years to maintain certified technician status. Each CARSI course awards a specific number of CECs upon completion. Credits are tracked automatically in your student dashboard and can be reported to the IICRC for renewal.',
+    },
+    {
+      question: 'Is CARSI training recognised by insurers?',
+      answer:
+        'CARSI courses are IICRC CEC-approved, and IICRC certification is recognised by major Australian insurers including IAG, Suncorp, and QBE as evidence of professional competency. CARSI is also a core pillar of the NRPG onboarding pathway.',
+    },
+    {
+      question: 'Can I complete training at my own pace?',
+      answer:
+        'Yes. All CARSI courses are available 24/7 and fully self-paced. You can pause mid-lesson, resume between jobs, and fit study around shift work or on-call rosters. There are no deadlines or scheduled class times.',
+    },
+    {
+      question: 'What industries does CARSI serve?',
+      answer:
+        'CARSI serves over 12 industries including healthcare, hospitality, aged care, mining and resources, commercial cleaning, government and defence, education, property management, strata, retail, childcare, and construction.',
+    },
+  ];
 }
 
 // ---------------------------------------------------------------------------
@@ -272,9 +265,7 @@ export default async function Home() {
       : ['WRT', 'CRT', 'ASD', 'AMRT', 'FSRT', 'OCT', 'CCT']
   );
   const disciplineCountLabel =
-    catalogueFacts.disciplineCodes.length > 0
-      ? catalogueFacts.disciplineCodes.length
-      : 7;
+    catalogueFacts.disciplineCodes.length > 0 ? catalogueFacts.disciplineCodes.length : 7;
 
   return (
     <div id="main-content" className="relative z-10 min-h-screen bg-[#050505]">
@@ -374,7 +365,7 @@ export default async function Home() {
         title="IICRC discipline map & pathways"
         className="bg-gradient-to-b from-[#2490ed]/[0.08] via-[#050505] to-transparent"
       >
-        <div className="grid gap-10 lg:grid-cols-12 lg:gap-14 lg:items-start">
+        <div className="grid gap-10 lg:grid-cols-12 lg:items-start lg:gap-14">
           <div className="space-y-6 lg:col-span-4">
             <p className="text-base leading-relaxed text-white/60 md:text-lg">
               Seven core pathways orbit <AcronymTooltip term="IICRC" /> standards — the same mental
@@ -383,14 +374,20 @@ export default async function Home() {
             </p>
             <ul className="space-y-3 text-sm text-white/45">
               <li className="flex gap-3">
-                <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[#2490ed]" aria-hidden />
+                <span
+                  className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[#2490ed]"
+                  aria-hidden
+                />
                 <span>
                   <strong className="text-white/70">Interactive hub</strong> — hover or tap any node
                   to see the full certification name and jump into filtered courses.
                 </span>
               </li>
               <li className="flex gap-3">
-                <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[#00d4aa]" aria-hidden />
+                <span
+                  className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[#00d4aa]"
+                  aria-hidden
+                />
                 <span>
                   <strong className="text-white/70">{disciplineCountLabel} disciplines</strong> in
                   this view, aligned with CARSI&apos;s published catalogue.
@@ -525,7 +522,7 @@ export default async function Home() {
             <AnimatedCard key={item.title} index={i}>
               <div className="group relative h-full overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-b from-white/[0.06] to-transparent p-6 shadow-[0_20px_60px_-40px_rgba(0,0,0,0.85)] transition-all duration-300 hover:border-white/18">
                 <div
-                  className="pointer-events-none absolute -right-8 -top-8 h-28 w-28 rounded-full opacity-30 blur-2xl transition-opacity group-hover:opacity-50"
+                  className="pointer-events-none absolute -top-8 -right-8 h-28 w-28 rounded-full opacity-30 blur-2xl transition-opacity group-hover:opacity-50"
                   style={{ background: item.color }}
                   aria-hidden
                 />
@@ -550,7 +547,10 @@ export default async function Home() {
         className="bg-gradient-to-b from-[#2490ed]/[0.05] to-transparent"
       >
         <div className="relative mx-auto max-w-3xl">
-          <div className="absolute inset-0 rounded-2xl bg-gradient-to-b from-[#2490ed]/20 to-transparent opacity-40 blur-3xl" aria-hidden />
+          <div
+            className="absolute inset-0 rounded-2xl bg-gradient-to-b from-[#2490ed]/20 to-transparent opacity-40 blur-3xl"
+            aria-hidden
+          />
           <div className="relative rounded-2xl border border-white/10 bg-gradient-to-b from-[#0a1524]/95 to-[#050505] p-6 shadow-[0_28px_90px_-48px_rgba(36,144,237,0.45)] sm:p-10">
             <div
               className="absolute inset-x-8 top-0 h-px bg-gradient-to-r from-transparent via-[#2490ed]/60 to-transparent"
@@ -662,7 +662,8 @@ export default async function Home() {
                   .{' '}
                   {catalogueFacts.publishedCourseCount > 0 ? (
                     <>
-                      CARSI offers {formatCourseCountForCopy(catalogueFacts.publishedCourseCount)}{' '}
+                      CARSI offers{' '}
+                      {formatCourseCountForCopy(catalogueFacts.publishedCourseCount)}{' '}
                     </>
                   ) : (
                     <>CARSI offers </>
@@ -816,7 +817,8 @@ export default async function Home() {
                 <div
                   className="flex h-14 w-14 items-center justify-center rounded-2xl text-lg font-bold shadow-[0_12px_40px_-16px_rgba(36,144,237,0.5)]"
                   style={{
-                    background: 'linear-gradient(135deg, rgba(36,144,237,0.25), rgba(255,255,255,0.06))',
+                    background:
+                      'linear-gradient(135deg, rgba(36,144,237,0.25), rgba(255,255,255,0.06))',
                     border: '1px solid rgba(255,255,255,0.2)',
                     color: '#2490ed',
                   }}
@@ -929,7 +931,7 @@ export default async function Home() {
             }}
           >
             <div
-              className="pointer-events-none absolute -right-20 -top-20 h-64 w-64 rounded-full blur-3xl"
+              className="pointer-events-none absolute -top-20 -right-20 h-64 w-64 rounded-full blur-3xl"
               style={{ background: 'rgba(36,144,237,0.2)' }}
               aria-hidden
             />
@@ -950,7 +952,8 @@ export default async function Home() {
                 <div
                   className="flex h-20 w-20 shrink-0 items-center justify-center rounded-2xl text-base font-bold tracking-tight shadow-[0_16px_48px_-20px_rgba(36,144,237,0.45)]"
                   style={{
-                    background: 'linear-gradient(145deg, rgba(255,255,255,0.12), rgba(36,144,237,0.2))',
+                    background:
+                      'linear-gradient(145deg, rgba(255,255,255,0.12), rgba(36,144,237,0.2))',
                     border: '1px solid rgba(255,255,255,0.2)',
                     color: '#fff',
                   }}
@@ -995,11 +998,7 @@ export default async function Home() {
       </AnimatedSection>
 
       {/* ── Certificate Preview ──────────────────────────────────────────── */}
-      <AnimatedSection
-        label="Credentials"
-        title="Verifiable Digital Certificates"
-        minimalHeader
-      >
+      <AnimatedSection label="Credentials" title="Verifiable Digital Certificates" minimalHeader>
         <div className="mx-auto max-w-xl">
           <p className="mb-6 text-center text-sm" style={{ color: 'rgba(255,255,255,0.5)' }}>
             Every completed course earns you a verifiable digital certificate with a public URL you
@@ -1023,7 +1022,7 @@ export default async function Home() {
               }}
             />
             <div
-              className="pointer-events-none absolute -right-24 top-1/2 h-72 w-72 -translate-y-1/2 rounded-full blur-3xl"
+              className="pointer-events-none absolute top-1/2 -right-24 h-72 w-72 -translate-y-1/2 rounded-full blur-3xl"
               style={{ background: 'rgba(237,157,36,0.12)' }}
               aria-hidden
             />
@@ -1058,8 +1057,7 @@ export default async function Home() {
                   href="/courses"
                   className="inline-flex items-center gap-2 rounded-full bg-[#ed9d24] px-8 py-3.5 text-sm font-bold text-[#1a1205] shadow-[0_12px_40px_-12px_rgba(237,157,36,0.55)] transition-transform hover:scale-[1.02]"
                 >
-                  Browse all courses{' '}
-                  <ArrowRight className="h-4 w-4" />
+                  Browse all courses <ArrowRight className="h-4 w-4" />
                 </Link>
               </div>
             </div>

--- a/data/wordpress-export/courses.json
+++ b/data/wordpress-export/courses.json
@@ -3,7 +3,7 @@
     "slug": "hvac-systems-and-indoor-air-quality",
     "title": "HVAC Systems and Indoor Air Quality: What Every Technician Should Know",
     "description": "<h3>Already Purchased This Course?</h3>\n<p><a href=\"https://carsi.com.au/courses/hvac-systems-and-indoor-air-quality-what-every-technician-should-know/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\"><strong>Introduction to Course</strong></li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\"><strong>Module 1: Understanding the Basics of HVAC and Airflow</strong></li>\n<li><strong>Module 2: Common HVAC Contaminants and Their Impact</strong></li>\n<li><strong>Module 3: Filtration and Air Cleaning Technologies</strong></li>\n<li><strong>Module 4: Ventilation: Fresh Air and IAQ</strong></li>\n<li><strong>Module 5: HVAC Maintenance and Air Quality Outcomes</strong></li>\n<li><strong>Module 6: Moisture Control and HVAC Systems</strong></li>\n<li><strong>Module 7: Ductwork: Inspection, Cleaning, and Sealing</strong></li>\n</ul>\n</li>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li><strong>Module 8: HVAC and Odour Control</strong></li>\n<li><strong>Module 9: Communicating IAQ Findings with Clients</strong></li>\n</ul>\n</li>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li><strong>Module 10: IAQ-Friendly HVAC Upgrades and Recommendations</strong></li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\nhis course provides HVAC technicians with essential knowledge and practical skills to assess, maintain, and optimise indoor air quality (IAQ) through HVAC system performance. Covering everything from airflow fundamentals to contaminant control, the course explains how HVAC components can either improve or degrade indoor environments depending on their design and maintenance.\nTechnicians will learn how to identify common IAQ hazards—such as mould, dust, VOCs, and odours—and explore solutions through proper filtration, ventilation, moisture control, duct maintenance, and HVAC system upgrades. Emphasis is also placed on clear client communication, helping technicians translate technical findings into actionable, relatable advice.\nWhether you&#8217;re troubleshooting an existing system or recommending upgrades, this course empowers you to deliver healthier, cleaner air and more comfortable living and working conditions for your clients.\n\n\n\n\n\n\n\n\n\nCourse Duration:\nApprox 2 Hours",
+    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\nhis course provides HVAC technicians with essential knowledge and practical skills to assess, maintain, and optimise indoor air quality (IAQ) through HVAC system performance. Covering everything from airflow fundamentals to contaminant control, the course explains how HVAC components can either improve or degrade indoor environments depending on their design and maintenance.\nTechnicians will learn how to identify common IAQ hazards\u2014such as mould, dust, VOCs, and odours\u2014and explore solutions through proper filtration, ventilation, moisture control, duct maintenance, and HVAC system upgrades. Emphasis is also placed on clear client communication, helping technicians translate technical findings into actionable, relatable advice.\nWhether you&#8217;re troubleshooting an existing system or recommending upgrades, this course empowers you to deliver healthier, cleaner air and more comfortable living and working conditions for your clients.\n\n\n\n\n\n\n\n\n\nCourse Duration:\nApprox 2 Hours",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2025/07/HVAC-SYSTEMS-INDOOR-AIR-QUALITY.png",
     "status": "draft",
     "price_aud": 0,
@@ -26,7 +26,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -66,7 +66,7 @@
     "slug": "dust-particulates-in-indoor-air",
     "title": "Dust and Particulates in Indoor Air: Control and Cleaning Strategies",
     "description": "<h3>Already Purchased This Course?</h3>\n<p><a href=\"https://carsi.com.au/courses/dust-and-particulates-in-indoor-air-control-and-cleaning-strategies/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\"><strong>Introduction to Course</strong></li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\"><strong>Module 1: Understanding Indoor Particulates</strong></li>\n<li><strong>Module 2: Health Impacts of Dust and Fine Particles</strong></li>\n<li><strong>Module 3: How Dust Moves Through Indoor Environments</strong></li>\n<li><strong>Module 4: Measuring Dust Levels and Airborne Particles</strong></li>\n<li><strong>Module 5: Filtration Technologies and Effectiveness</strong></li>\n<li><strong>Module 6: Cleaning Strategies for Dust Control</strong></li>\n<li><strong>Module 7: HVAC Systems and Dust Management</strong></li>\n</ul>\n</li>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li><strong>Module 8: Source Control and Prevention Techniques</strong></li>\n<li><strong>Module 9: Monitoring and Maintaining Air Quality Over Time</strong></li>\n</ul>\n</li>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li><strong>Module 10: Communicating Findings and Recommendations</strong></li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\nThis course equips professionals with the knowledge and tools to identify, manage, and reduce indoor dust and particulate pollution across residential, commercial, and restoration environments. Participants will explore how particulates form, how they move, and their potential health impacts—including respiratory, cardiovascular, and cognitive effects.\nThe course covers measurement technologies like particle counters, filtration methods including HEPA and MERV-rated filters, and effective cleaning strategies to reduce both airborne and settled dust. Learners will also gain insight into HVAC system influence, source control practices, and long-term air quality monitoring.\nBy the end of the course, technicians will be able to assess indoor particulate levels, recommend targeted interventions, and communicate findings and solutions clearly to clients—promoting healthier, cleaner indoor environments.\n\n\n\n\n\n\n\n\n\nCourse Duration:\nApprox 2 Hours",
+    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\nThis course equips professionals with the knowledge and tools to identify, manage, and reduce indoor dust and particulate pollution across residential, commercial, and restoration environments. Participants will explore how particulates form, how they move, and their potential health impacts\u2014including respiratory, cardiovascular, and cognitive effects.\nThe course covers measurement technologies like particle counters, filtration methods including HEPA and MERV-rated filters, and effective cleaning strategies to reduce both airborne and settled dust. Learners will also gain insight into HVAC system influence, source control practices, and long-term air quality monitoring.\nBy the end of the course, technicians will be able to assess indoor particulate levels, recommend targeted interventions, and communicate findings and solutions clearly to clients\u2014promoting healthier, cleaner indoor environments.\n\n\n\n\n\n\n\n\n\nCourse Duration:\nApprox 2 Hours",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2025/07/DUST-AND-PARTICULATES.png",
     "status": "draft",
     "price_aud": 0,
@@ -89,7 +89,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -152,7 +152,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -192,7 +192,7 @@
     "slug": "air-quality-and-odour",
     "title": "Air Quality and Odour: Identification and Deodorisation Essentials",
     "description": "<h3>Already Purchased This Course?</h3>\n<p><a href=\"https://carsi.com.au/courses/air-quality-and-odour-identification-and-deodorisation-essentials/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\"><strong>Introduction to Course</strong></li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\"><strong>Module 1: What is Odour and Why it Matters</strong></li>\n<li><strong>Module 2: Categories of Odours and Their Characteristics</strong></li>\n<li><strong>Module 3: Common Indoor Sources of Odours</strong></li>\n<li><strong>Module 4: Odour and Volatile Organic Compounds (VOCs)</strong></li>\n<li><strong>Module 5: Assessment and Documentation Techniques</strong></li>\n<li><strong>Module 6: Ventilation and Air Movement Considerations</strong></li>\n<li><strong style=\"font-size: 16px;\">Module 7: Deodorisation Methods and When to Use Them</strong></li>\n</ul>\n</li>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li><strong style=\"font-size: 16px;\"><strong style=\"font-size: 16px;\">Module 8: Equipment Setups for Odour Control</strong></strong></li>\n<li><strong style=\"font-size: 16px;\">Module 9: Safety, Occupant Communication, and Expectations</strong></li>\n</ul>\n</li>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li><strong>Module 10: Final Odour Clearance and Verification</strong></li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\nThis course aims to provide restoration, cleaning, and HVAC professionals with the essential knowledge and practical skills needed to identify, assess, and effectively address indoor air quality issues related to odour. Through a comprehensive exploration of odour science, source identification, deodorisation methods, and air treatment technologies, participants will learn how to tackle odour problems at their root—not just mask them.\nWith a focus on health, safety, and long-term remediation success, this course equips learners to improve occupant wellbeing, enhance service outcomes, and confidently manage odour challenges in a variety of restoration scenarios.\n\n\n\n\n\n\n\n\n\nCourse Duration:\nApprox 2 Hours",
+    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\nThis course aims to provide restoration, cleaning, and HVAC professionals with the essential knowledge and practical skills needed to identify, assess, and effectively address indoor air quality issues related to odour. Through a comprehensive exploration of odour science, source identification, deodorisation methods, and air treatment technologies, participants will learn how to tackle odour problems at their root\u2014not just mask them.\nWith a focus on health, safety, and long-term remediation success, this course equips learners to improve occupant wellbeing, enhance service outcomes, and confidently manage odour challenges in a variety of restoration scenarios.\n\n\n\n\n\n\n\n\n\nCourse Duration:\nApprox 2 Hours",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2025/07/air-quality-and-odour.png",
     "status": "draft",
     "price_aud": 0,
@@ -215,7 +215,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -278,7 +278,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -341,7 +341,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -404,7 +404,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -467,7 +467,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -507,7 +507,7 @@
     "slug": "introduction-to-air-quality-fundamentals",
     "title": "Introduction to Air Quality Fundamentals",
     "description": "<h3>Already Purchased This Course?</h3>\n<p><a href=\"https://carsi.com.au/courses/introduction-to-air-quality-fundamentals/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\"><strong>Introduction to Air Quality Fundamentals for Restoration and Cleaning Professionals</strong></li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\"><strong>Module 1: Understanding Indoor Air Quality (IAQ)</strong></li>\n<li><strong>Module 2: Common Indoor Air Contaminants in Restoration and Cleaning</strong></li>\n<li><strong>Module 3: Ventilation and Air Exchange Principles</strong></li>\n<li><strong>Module 4: Air Quality Monitoring and Assessment Tools</strong></li>\n<li><strong>Module 5: Strategies to Improve and Maintain Air Quality</strong></li>\n<li><strong>Quiz</strong></li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\nThis foundational course introduces restoration and cleaning professionals to the essential principles of indoor air quality (IAQ). You&#8217;ll learn how everyday tasks—from water damage restoration to post-construction cleaning—can impact the air we breathe.\nThrough five practical modules, you’ll explore common indoor contaminants, ventilation and pressure control, air monitoring tools, and strategies to improve and maintain healthy air during and after restoration work. Whether you’re new to the field or looking to refresh your knowledge, this course equips you with actionable insights to enhance safety, compliance, and client trust on every job.\n\n\n\n\n\n\n\n\n\nCourse Duration:\nApprox 1 Hour\n\n\nThe IICRC does not endorse any educational provider, product, offering, or service.\nThe Institute expressly disclaims responsibility, endorsement or warranty for third-party\npublications, products, certifications, or instruction. The approved status does not award\nIICRC Certification, only qualified continuing education hours.",
+    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\nThis foundational course introduces restoration and cleaning professionals to the essential principles of indoor air quality (IAQ). You&#8217;ll learn how everyday tasks\u2014from water damage restoration to post-construction cleaning\u2014can impact the air we breathe.\nThrough five practical modules, you\u2019ll explore common indoor contaminants, ventilation and pressure control, air monitoring tools, and strategies to improve and maintain healthy air during and after restoration work. Whether you\u2019re new to the field or looking to refresh your knowledge, this course equips you with actionable insights to enhance safety, compliance, and client trust on every job.\n\n\n\n\n\n\n\n\n\nCourse Duration:\nApprox 1 Hour\n\n\nThe IICRC does not endorse any educational provider, product, offering, or service.\nThe Institute expressly disclaims responsibility, endorsement or warranty for third-party\npublications, products, certifications, or instruction. The approved status does not award\nIICRC Certification, only qualified continuing education hours.",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2025/04/air-quality-cover-2.png",
     "status": "published",
     "price_aud": 29,
@@ -530,7 +530,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -570,7 +570,7 @@
     "slug": "antiques",
     "title": "Introduction to Restoration of Antiques and Fine Furnishings",
     "description": "<h2>Already Purchased This Course?</h2>\n<p><a href=\"https://carsi.com.au/courses/introduction-to-restoration-of-antiques-and-fine-furnishings/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Material Integrity Risks</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Handling Precautions</li>\n<li>Cleaning Technique Selection</li>\n<li>Restorative Methodologies</li>\n<li>Authentication and Appraisals</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\nThis course aims to provide a basic but comprehensive understanding of the risks and techniques involved in the restoration of antique and delicate furniture exposed to moisture and environmental fluctuations.\nCovering material integrity challenges like bonding damage, fungal colonization, and chemical degradation, it also includes handling precautions, cleaning methods, and restorative techniques.\nWith a focus on maintaining authenticity, the course emphasizes meticulous procedures for preserving historical value, ensuring safe handling, and documenting provenance to uphold both aesthetic and market value.\n\n\n\n\n\n\n\n\n\n \nCourse Duration:\nApprox 1 Hour",
+    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\nThis course aims to provide a basic but comprehensive understanding of the risks and techniques involved in the restoration of antique and delicate furniture exposed to moisture and environmental fluctuations.\nCovering material integrity challenges like bonding damage, fungal colonization, and chemical degradation, it also includes handling precautions, cleaning methods, and restorative techniques.\nWith a focus on maintaining authenticity, the course emphasizes meticulous procedures for preserving historical value, ensuring safe handling, and documenting provenance to uphold both aesthetic and market value.\n\n\n\n\n\n\n\n\n\n\u00a0\nCourse Duration:\nApprox 1 Hour",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2024/11/ANTIQUES-COURSE.png",
     "status": "published",
     "price_aud": 0,
@@ -593,7 +593,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -628,7 +628,7 @@
     "slug": "submerged-items-recovery",
     "title": "Introduction to Recovery of Submerged Items and Contents",
     "description": "<h2>Already Purchased This Course?</h2>\n<p><a href=\"https://carsi.com.au/courses/introduction-to-recovery-of-submerged-items-and-contents/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Evaluating Restorability</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Recovery Logistics</li>\n<li>Initial Preservation</li>\n<li>Cleaning Methods</li>\n<li>Functionality Validation</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\nThis course aims to provide a comprehensive framework for evaluating and restoring assets affected by water damage, guiding participants through the critical stages of restoration.\nIt covers assessing materials&#8217; restorability based on composition, contamination, and damage history, alongside recovery logistics such as safety protocols, specialized equipment, and transport protection.\nAdditionally, it delves into preservation techniques, including drying conditions, packaging, and monitoring. Finally, it addresses effective cleaning methods and functionality validation, ensuring long-term viability and stability for restored assets.\n\n\n\n\n\n\n\n\n\n \nCourse Duration:\nApprox 1 Hour",
+    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\nThis course aims to provide a comprehensive framework for evaluating and restoring assets affected by water damage, guiding participants through the critical stages of restoration.\nIt covers assessing materials&#8217; restorability based on composition, contamination, and damage history, alongside recovery logistics such as safety protocols, specialized equipment, and transport protection.\nAdditionally, it delves into preservation techniques, including drying conditions, packaging, and monitoring. Finally, it addresses effective cleaning methods and functionality validation, ensuring long-term viability and stability for restored assets.\n\n\n\n\n\n\n\n\n\n\u00a0\nCourse Duration:\nApprox 1 Hour",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2024/11/SUBMERGED-ITEMS-COURSE.png",
     "status": "published",
     "price_aud": 0,
@@ -651,7 +651,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -686,7 +686,7 @@
     "slug": "drying-transportation",
     "title": "Introduction to Drying Transportation and Vehicles",
     "description": "<h3>Already Purchased This Course? </h3>\n<p>\t\t\t\t\t<a href=\"https://carsi.com.au/courses/introduction-to-drying-transportation-and-vehicles/\"><br />\n\t\t\t\t\t\t\t\t\tAccess Here<br />\n\t\t\t\t\t</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Flooded Vehicle Considerations</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Drying Dynamics</li>\n<li>Protecting Contents</li>\n<li>Monitoring and Validation</li>\n<li>Reconstitution Procedures</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\nThis course aims to provide a comprehensive understanding of drying techniques and restoration strategies specifically for transportation and vehicles affected by flooding.\nParticipants will learn about key considerations in handling flooded vehicles, such as addressing electrical system damage, corrosion potentials, and contaminant residues.\nThe course also covers advanced drying dynamics, including ventilation and airflow management, and provides guidance on protecting vehicle contents and ensuring thorough monitoring and validation.\nLastly, participants will learn best practices for final reconstitution procedures, ensuring fully restored functionality and safety.\n\n\n\n\n\n\n\n\n\n \nCourse Duration:\nApprox 1 Hour",
+    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\nThis course aims to provide a comprehensive understanding of drying techniques and restoration strategies specifically for transportation and vehicles affected by flooding.\nParticipants will learn about key considerations in handling flooded vehicles, such as addressing electrical system damage, corrosion potentials, and contaminant residues.\nThe course also covers advanced drying dynamics, including ventilation and airflow management, and provides guidance on protecting vehicle contents and ensuring thorough monitoring and validation.\nLastly, participants will learn best practices for final reconstitution procedures, ensuring fully restored functionality and safety.\n\n\n\n\n\n\n\n\n\n\u00a0\nCourse Duration:\nApprox 1 Hour",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2024/11/Copy-of-Copy-of-Copy-of-Copy-of-Live-AI-course-graphic-idea-3.png",
     "status": "published",
     "price_aud": 0,
@@ -709,7 +709,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -744,7 +744,7 @@
     "slug": "industrial-2",
     "title": "Introduction to Drying Industrial and Manufacturing Sites",
     "description": "<h3>Already Purchased This Course? </h3>\n<p>\t\t\t\t\t<a href=\"https://carsi.com.au/courses/introduction-to-drying-industrial-and-manufacturing-sites/\"><br />\n\t\t\t\t\t\t\t\t\tAccess Here<br />\n\t\t\t\t\t</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Production Considerations</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Hazard Communication</li>\n<li>Reconstituting Operations</li>\n<li>Drying Complex Materials</li>\n<li>Achieving Regulatory Compliance</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\nThis course aims to equip healthcare facility managers and emergency response teams with essential strategies for managing facility disruptions and maintaining regulatory compliance. Participants will learn to minimize operational, financial, and reputational risks through moisture control, microbial prevention, and quality standards maintenance.\nKey topics include business interruption management, equipment protection, regulatory updates, and clearance certification.\nBy implementing containment, ventilation, and air quality monitoring, facilities can enhance safety, protect sensitive equipment, and ensure smooth, compliant operations during emergencies.\n\n\n\n\n\n\n\n\n \nCourse Duration:\nApprox 1 Hour",
+    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\nThis course aims to equip healthcare facility managers and emergency response teams with essential strategies for managing facility disruptions and maintaining regulatory compliance. Participants will learn to minimize operational, financial, and reputational risks through moisture control, microbial prevention, and quality standards maintenance.\nKey topics include business interruption management, equipment protection, regulatory updates, and clearance certification.\nBy implementing containment, ventilation, and air quality monitoring, facilities can enhance safety, protect sensitive equipment, and ensure smooth, compliant operations during emergencies.\n\n\n\n\n\n\n\n\n\u00a0\nCourse Duration:\nApprox 1 Hour",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2024/10/INDUSTRIAL-SITE-COURSE-2.png",
     "status": "published",
     "price_aud": 0,
@@ -767,7 +767,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -802,7 +802,7 @@
     "slug": "educational",
     "title": "Introduction to Drying Educational and Institutional Sites",
     "description": "<h3>Already Purchased This Course? </h3>\n<p>\t\t\t\t\t<a href=\"https://carsi.com.au/courses/introduction-to-drying-educational-and-institutional-sites/\"><br />\n\t\t\t\t\t\t\t\t\tAccess Here<br />\n\t\t\t\t\t</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Special Design Features</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Shared Infrastructure</li>\n<li>Building Population Factors</li>\n<li>Regulatory Oversight</li>\n<li>Loss Limitation Tactics</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\nThis course aims to provide professionals with critical strategies for managing drying processes in educational, institutional, and healthcare settings, addressing complex challenges such as infrastructure protection, health and accessibility needs, research continuity, and regulatory compliance. Topics cover safeguarding sensitive environments—such as laboratories, data centers, and auditoriums—while ensuring environmental controls, power distribution, and fire protection are maintained. It prepares staff to limit losses, support temporary relocations, and uphold the well-being of campus communities.\n\n\n\n\n\n\n\n\n \nCourse Duration:\nApprox 1 Hour",
+    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\nThis course aims to provide professionals with critical strategies for managing drying processes in educational, institutional, and healthcare settings, addressing complex challenges such as infrastructure protection, health and accessibility needs, research continuity, and regulatory compliance. Topics cover safeguarding sensitive environments\u2014such as laboratories, data centers, and auditoriums\u2014while ensuring environmental controls, power distribution, and fire protection are maintained. It prepares staff to limit losses, support temporary relocations, and uphold the well-being of campus communities.\n\n\n\n\n\n\n\n\n\u00a0\nCourse Duration:\nApprox 1 Hour",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2024/10/EDUCATIONAL-SITES-COURSE-1.png",
     "status": "published",
     "price_aud": 0,
@@ -825,7 +825,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -860,7 +860,7 @@
     "slug": "hospitality",
     "title": "Introduction to Drying Hospitality and Lodging Sites",
     "description": "<h3>Already Purchased This Course? </h3>\n<p>\t\t\t\t\t<a href=\"https://carsi.com.au/courses/introduction-to-drying-hospitality-and-lodging-sites/\"><br />\n\t\t\t\t\t\t\t\t\tAccess Here<br />\n\t\t\t\t\t</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Business Operations Impacts</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Room and Content Considerations</li>\n<li>Stuctural Repair Stating</li>\n<li>Reconstructive Constraints</li>\n<li>Remediation Clean Up</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nThis course, Introduction to Drying Hospitality and Lodging Sites, aims to provide a comprehensive understanding of the operational and structural impacts of water damage in hospitality venues.\nParticipants will learn how to manage revenue interruptions, booking displacements, and utility infrastructure challenges specific to lodging sites. The course also covers strategies for protecting room contents, restoring historical decor, and implementing phased structural repairs.\nAdditionally, it addresses key remediation techniques, including environmental safety testing and microbial prevention, ensuring effective recovery and long-term site safety.\n\n\n\n\n\n\n\n \nCourse Duration:\nApprox 1 Hour",
+    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nThis course, Introduction to Drying Hospitality and Lodging Sites, aims to provide a comprehensive understanding of the operational and structural impacts of water damage in hospitality venues.\nParticipants will learn how to manage revenue interruptions, booking displacements, and utility infrastructure challenges specific to lodging sites. The course also covers strategies for protecting room contents, restoring historical decor, and implementing phased structural repairs.\nAdditionally, it addresses key remediation techniques, including environmental safety testing and microbial prevention, ensuring effective recovery and long-term site safety.\n\n\n\n\n\n\n\n\u00a0\nCourse Duration:\nApprox 1 Hour",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2024/10/HOSPITALITY-SITES-COURSE.png",
     "status": "published",
     "price_aud": 0,
@@ -883,7 +883,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -925,7 +925,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
     "cec_hours": null,
@@ -936,7 +936,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         }
       ],
@@ -951,7 +951,7 @@
     "slug": "drying-healthcare",
     "title": "Introduction to Drying Health Care Facilities",
     "description": "<h3>Already Purchased This Course? </h3>\n<p>\t\t\t\t\t<a href=\"https://carsi.com.au/courses/introduction-to-drying-health-care-facilities/\"><br />\n\t\t\t\t\t\t\t\t\tAccess Here<br />\n\t\t\t\t\t</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Introduction to Drying Health Care Facilities</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Special Design Considerations</li>\n<li>Unique Building Systems</li>\n<li>Infection Control Risks</li>\n<li>Maintaining Critical Operations</li>\n<li>Remediation Standards</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nThis course aims to provide a foundational understanding of the essential principles and practices involved in drying healthcare facilities.\nThe modules will cover special design considerations, unique building systems, infection control risks, maintaining critical operations, and adherence to remediation standards.\n\n\n\n\n\n\n\n \nCourse Duration:\nApprox 1 Hour",
+    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nThis course aims to provide a foundational understanding of the essential principles and practices involved in drying healthcare facilities.\nThe modules will cover special design considerations, unique building systems, infection control risks, maintaining critical operations, and adherence to remediation standards.\n\n\n\n\n\n\n\n\u00a0\nCourse Duration:\nApprox 1 Hour",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2024/09/Copy-of-Copy-of-Copy-of-Copy-of-Copy-of-Copy-of-Copy-of-INTRO-SERIES-MEMBERSHIP.png",
     "status": "published",
     "price_aud": 0,
@@ -974,7 +974,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -1009,7 +1009,7 @@
     "slug": "ultraviolet",
     "title": "Introduction to Ultraviolet Light and Fluorescence",
     "description": "<h2>Already Purchased This Course?</h2>\n<p><a href=\"https://carsi.com.au/courses/introduction-to-ultraviolet-light-and-fluorescence/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Introduction to Ultraviolet Light and Fluorescence</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Ultraviolet Light Spectrum</li>\n<li>Fluorescence Principles</li>\n<li>Equipment Application</li>\n<li>Water Loss Inspection Uses</li>\n<li>Complimentary Technologies</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nThis course aims to provide a basic but comprehensive understanding of ultraviolet light spectrum applications and safety in water loss inspections.\nIt covers the properties of UVA, UVB, and UVC light, their fluorescence principles, and the protective measures required for safe use.\nParticipants will also explore equipment types, moisture detection, microbial growth identification, and complementary technologies such as infrared thermography and moisture mapping to enhance inspection accuracy and efficiency.\n\n\n\n\n\n\n\n \nCourse Duration:\nApprox  1 hour",
+    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nThis course aims to provide a basic but comprehensive understanding of ultraviolet light spectrum applications and safety in water loss inspections.\nIt covers the properties of UVA, UVB, and UVC light, their fluorescence principles, and the protective measures required for safe use.\nParticipants will also explore equipment types, moisture detection, microbial growth identification, and complementary technologies such as infrared thermography and moisture mapping to enhance inspection accuracy and efficiency.\n\n\n\n\n\n\n\n\u00a0\nCourse Duration:\nApprox\u00a0 1 hour",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2024/09/Copy-of-Copy-of-Copy-of-Copy-of-Copy-of-Copy-of-INTRO-SERIES-MEMBERSHIP.png",
     "status": "published",
     "price_aud": 0,
@@ -1032,7 +1032,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -1067,7 +1067,7 @@
     "slug": "infrared",
     "title": "Introduction to Infrared Thermography for Drying",
     "description": "<h3>Already Purchased This Course? </h3>\n<p>\t\t\t\t\t<a href=\"https://carsi.com.au/courses/introduction-to-infrared-thermography-for-drying/\"><br />\n\t\t\t\t\t\t\t\t\tAccess Here<br />\n\t\t\t\t\t</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Introduction to Infrared Thermography for Drying</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Thermal Energy Concepts</li>\n<li>Infrared Camera Technologies</li>\n<li>Moisture Detection Applications</li>\n<li>Safely Applying Thermography</li>\n<li>Result Analysis and Applications</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nThis course aims to provide a basic but comprehensive understanding of thermal energy concepts and infrared thermography for moisture detection and drying in restoration. It covers heat transfer principles, surface temperature dynamics, and emissivity effects, alongside infrared camera technologies and moisture detection applications. Participants will also learn about thermography safety protocols, result analysis, and the integration of thermographic data into remediation strategies for precise drying and moisture management.\n\n\n\n\n\n\n \nCourse Duration:\nApprox 1 Hour",
+    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nThis course aims to provide a basic but comprehensive understanding of thermal energy concepts and infrared thermography for moisture detection and drying in restoration. It covers heat transfer principles, surface temperature dynamics, and emissivity effects, alongside infrared camera technologies and moisture detection applications. Participants will also learn about thermography safety protocols, result analysis, and the integration of thermographic data into remediation strategies for precise drying and moisture management.\n\n\n\n\n\n\n\u00a0\nCourse Duration:\nApprox 1 Hour",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2024/09/Copy-of-Copy-of-Copy-of-Copy-of-Copy-of-INTRO-SERIES-MEMBERSHIP-1.png",
     "status": "published",
     "price_aud": 0,
@@ -1090,7 +1090,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -1125,7 +1125,7 @@
     "slug": "litigation-support",
     "title": "Introduction to Water Damage Litigation Support",
     "description": "<h2>Already Purchased This Course?</h2>\n<p><a href=\"https://carsi.com.au/courses/introduction-to-water-damage-litigation-support/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Introduction to Water Damage Litigation Support</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Forensic Investigations</li>\n<li>Data Gathering</li>\n<li>Scope Analysis</li>\n<li>Report Creation</li>\n<li>Legal Proceedings</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nThis course aims to provide a basic but comprehensive understanding of forensic investigations in the restoration industry. \nParticipants will explore moisture source tracing, material failure analysis, and code compliance assessments. Through data gathering techniques like psychrometric records and sensor mapping, alongside scope analysis and report creation, the course offers insights into legal proceedings, evidence management, and expert testimony preparation, ensuring a thorough approach to restoration case investigations.\n\n\n\n\n\n\n\n \nCourse Duration:\nApprox 1 Hour",
+    "short_description": "What can you expect from this Course?\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nThis course aims to provide a basic but comprehensive understanding of forensic investigations in the restoration industry. \nParticipants will explore moisture source tracing, material failure analysis, and code compliance assessments. Through data gathering techniques like psychrometric records and sensor mapping, alongside scope analysis and report creation, the course offers insights into legal proceedings, evidence management, and expert testimony preparation, ensuring a thorough approach to restoration case investigations.\n\n\n\n\n\n\n\n\u00a0\nCourse Duration:\nApprox 1 Hour",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2024/09/Copy-of-Copy-of-Copy-of-Copy-of-Copy-of-INTRO-SERIES-MEMBERSHIP.png",
     "status": "published",
     "price_aud": 0,
@@ -1148,7 +1148,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -1183,7 +1183,7 @@
     "slug": "advanced-applied",
     "title": "Introduction to Advanced Applied Structural Drying",
     "description": "<h3>Already Purchased This Course? </h3>\n<p>\t\t\t\t\t<a href=\"https://carsi.com.au/courses/introduction-to-advanced-applied-structural-drying/\"><br />\n\t\t\t\t\t\t\t\t\tAccess Here<br />\n\t\t\t\t\t</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Introduction to Advanced Applied Structural Drying</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Psychrometric Analysis</li>\n<li>Drying Strategy Development</li>\n<li>Moisture Removal Techniques</li>\n<li>Monitoring Drying Progress</li>\n<li>Verifying Completion</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\nThis course aims to provide restoration professionals with basic but comprehensive skills in psychrometric analysis, drying strategy development, and moisture removal techniques.\nTopics include airflow calculations, microclimate mapping, sensor integration, and managing energy loads.\nAdditionally, it covers developing efficient drying strategies, using supplemental devices, and monitoring drying progress to ensure successful moisture removal.\nFinally, participants will learn methods for verifying completion through moisture quantification, stability confirmations, and asset preservation techniques.\n \nCourse Duration:\nApprox 1 Hour",
+    "short_description": "What can you expect from this Course?\n\nThis course aims to provide restoration professionals with basic but comprehensive skills in psychrometric analysis, drying strategy development, and moisture removal techniques.\nTopics include airflow calculations, microclimate mapping, sensor integration, and managing energy loads.\nAdditionally, it covers developing efficient drying strategies, using supplemental devices, and monitoring drying progress to ensure successful moisture removal.\nFinally, participants will learn methods for verifying completion through moisture quantification, stability confirmations, and asset preservation techniques.\n\u00a0\nCourse Duration:\nApprox 1 Hour",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2024/09/Copy-of-Copy-of-Copy-of-INTRO-SERIES-MEMBERSHIP-17-1.png",
     "status": "published",
     "price_aud": 0,
@@ -1206,7 +1206,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -1241,7 +1241,7 @@
     "slug": "asbestos",
     "title": "Introduction to Asbestos: Asbestos Awareness",
     "description": "<h3>Already Purchased This Course? </h3>\n<p>\t\t\t\t\t<a href=\"https://carsi.com.au/courses/introduction-to-asbestos-asbestos-awareness/\"><br />\n\t\t\t\t\t\t\t\t\tAccess Here<br />\n\t\t\t\t\t</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Introduction to Asbestos: Asbestos Awareness</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">History and Use of Asbestos</li>\n<li>Dangers of Asbestos</li>\n<li>Types of Asbestos Containing Materials</li>\n<li>Handling Asbestos Containing Materials</li>\n<li>Containing Asbestos if Damaged or Identified</li>\n<li>Reporting and Documentation</li>\n<li>Training and Certification</li>\n<li>Legal and Regulatory Requirements</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\nThe Asbestos Awareness Course aims to offer a thorough introduction to asbestos, its types, history, and the associated health risks. It covers the identification of asbestos-containing materials, proper handling procedures, and the importance of personal protective equipment (PPE). The course also emphasizes legal compliance, advanced training, and certification requirements, ensuring safe asbestos management and abatement in construction and restoration work.\n \nCourse Duration:\nApprox 30 Minutes",
+    "short_description": "What can you expect from this Course?\n\nThe Asbestos Awareness Course aims to offer a thorough introduction to asbestos, its types, history, and the associated health risks. It covers the identification of asbestos-containing materials, proper handling procedures, and the importance of personal protective equipment (PPE). The course also emphasizes legal compliance, advanced training, and certification requirements, ensuring safe asbestos management and abatement in construction and restoration work.\n\u00a0\nCourse Duration:\nApprox 30 Minutes",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2024/08/Copy-of-Copy-of-INTRO-SERIES-MEMBERSHIP.png",
     "status": "published",
     "price_aud": 29,
@@ -1264,7 +1264,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -1311,7 +1311,7 @@
     "is_free": true,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
     "cec_hours": null,
@@ -1322,7 +1322,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -1357,7 +1357,7 @@
     "slug": "dehumidifiers",
     "title": "Refrigerant Dehumidifiers for Water Loss Restoration",
     "description": "<h2>Already Purchased This Course?</h2>\n<p><a href=\"https://carsi.com.au/courses/refrigerant-dehumidifiers-for-water-loss-restoration-a-beginners-guide/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Introduction to Refrigerant Dehumidifiers</li>\n<li>Low Grain Refrigerant Technology</li>\n<li>Sizing and Calculating Dehumidifier Requirements</li>\n<li>Operating Temperatures and Efficiency</li>\n<li>Refrigerants Used in Modern Dehumidifiers</li>\n<li>Essential Accessories for Dehumidifiers</li>\n<li>Maintenance and Care</li>\n<li>Practice Application in Water Loss Scenarios</li>\n<li>Safety Considerations</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\nThis course aims to provide a comprehensive understanding of refrigerant dehumidifiers for water loss restoration. It covers the fundamentals of refrigerant dehumidifiers, including popular models from Phoenix, Dri-Eaz, and Ecor Pro, and delves into Low Grain Refrigerant (LGR) technology. Participants will learn to size and calculate dehumidifier requirements, optimize operating temperatures, and select essential accessories. The course includes practical applications in water loss scenarios, maintenance and care routines, and crucial safety considerations to ensure efficient and safe operation in various environments.\n \n \n \nCourse Duration:\nApprox 4Hours",
+    "short_description": "What can you expect from this Course?\n\nThis course aims to provide a comprehensive understanding of refrigerant dehumidifiers for water loss restoration. It covers the fundamentals of refrigerant dehumidifiers, including popular models from Phoenix, Dri-Eaz, and Ecor Pro, and delves into Low Grain Refrigerant (LGR) technology. Participants will learn to size and calculate dehumidifier requirements, optimize operating temperatures, and select essential accessories. The course includes practical applications in water loss scenarios, maintenance and care routines, and crucial safety considerations to ensure efficient and safe operation in various environments.\n\u00a0\n \n \nCourse Duration:\nApprox 4Hours",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2024/07/Copy-of-Copy-of-Copy-of-Copy-of-Copy-of-Copy-of-Copy-of-Copy-of-drying-techniques-6.png",
     "status": "published",
     "price_aud": 0,
@@ -1380,7 +1380,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -1422,7 +1422,7 @@
     "is_free": true,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "ASD",
     "cec_hours": null,
@@ -1433,7 +1433,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -1475,7 +1475,7 @@
     "is_free": true,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "ASD",
     "cec_hours": null,
@@ -1486,7 +1486,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -1528,7 +1528,7 @@
     "is_free": true,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "ASD",
     "cec_hours": null,
@@ -1539,7 +1539,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -1586,7 +1586,7 @@
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -1599,7 +1599,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -1647,7 +1647,7 @@
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -1660,7 +1660,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -1738,7 +1738,7 @@
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 2.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -1751,7 +1751,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -1809,7 +1809,7 @@
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -1822,7 +1822,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -1863,7 +1863,7 @@
     "slug": "risk-assessment-course-ccw",
     "title": "Risk Assessment Course - CCW",
     "description": "<style>/*! elementor - v3.12.2 - 23-04-2023 */<br />.elementor-heading-title{padding:0;margin:0;line-height:1}.elementor-widget-heading .elementor-heading-title[class*=elementor-size-]>a{color:inherit;font-size:inherit;line-height:inherit}.elementor-widget-heading .elementor-heading-title.elementor-size-small{font-size:15px}.elementor-widget-heading .elementor-heading-title.elementor-size-medium{font-size:19px}.elementor-widget-heading .elementor-heading-title.elementor-size-large{font-size:29px}.elementor-widget-heading .elementor-heading-title.elementor-size-xl{font-size:39px}.elementor-widget-heading .elementor-heading-title.elementor-size-xxl{font-size:59px}</style>\n<h2>Already Purchased This Course?</h2>\n<p><a role=\"button\" href=\"/courses/risk-assessment-course/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Introduction to WH&amp;S</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Hazards and Risks</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Hazard Identification</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Managing Risks</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Risk Matrix</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Job Safety and Environmental Analysis</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Safe Work Method Statements</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">WH&amp;S Communication and Consultation</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Quiz</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\nRisk Management is one of the most important aspects within an organisation. It is a LEGAL obligation under the Workplace Health and Safety Act that all staff are trained to manage WHS risks.\nCARSI&#8217;s Risk Assessment Course aims to improve the participants awareness and knowledge on managing risks. The objectives of this course include, increase awareness of the need to identify hazards, Improve the ability to identify hazards within the workplace, increase understanding of how to evaluate hazards and the associated risks and more.\nCourse Duration:\nApproximately 1.5 Hours\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC) : 2 Hours\nOnce completed please email support@carsi.com.au for your Certificate of completion confirming your hours of Continuing Education Credits.\n\n\nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
+    "short_description": "What can you expect from this Course?\nRisk Management is one of the most important aspects within an organisation. It is a\u00a0LEGAL\u00a0obligation under the Workplace Health and Safety Act that all staff are trained to manage WHS risks.\nCARSI&#8217;s Risk Assessment Course aims to improve the participants awareness and knowledge on managing risks. The objectives of this course include, increase awareness of the need to identify hazards, Improve the ability to identify hazards within the workplace, increase understanding of how to evaluate hazards and the associated risks and more.\nCourse Duration:\nApproximately 1.5 Hours\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC) : 2 Hours\nOnce completed please email support@carsi.com.au for your Certificate of completion confirming your hours of Continuing Education Credits.\n\n\nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2021/09/RISK-ASSESSMENT.png",
     "status": "published",
     "price_aud": 99,
@@ -1875,7 +1875,7 @@
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 2.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -1888,7 +1888,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -1961,12 +1961,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 5.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -1974,7 +1974,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -2037,7 +2037,7 @@
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 3.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -2050,7 +2050,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -2108,12 +2108,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 5.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -2121,7 +2121,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -2189,7 +2189,7 @@
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -2202,7 +2202,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -2270,12 +2270,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 5.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -2283,7 +2283,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -2356,12 +2356,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 4.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -2369,7 +2369,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -2437,12 +2437,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 2.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -2450,7 +2450,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -2523,7 +2523,7 @@
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -2536,7 +2536,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -2589,12 +2589,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": "WRT",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -2602,7 +2602,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -2653,19 +2653,19 @@
     "slug": "introduction-to-water-damage-restoration-course-ccw",
     "title": "Introduction to Water Damage Restoration - CCW",
     "description": "<style>/*! elementor - v3.18.0 - 06-12-2023 */<br />.elementor-heading-title{padding:0;margin:0;line-height:1}.elementor-widget-heading .elementor-heading-title[class*=elementor-size-]>a{color:inherit;font-size:inherit;line-height:inherit}.elementor-widget-heading .elementor-heading-title.elementor-size-small{font-size:15px}.elementor-widget-heading .elementor-heading-title.elementor-size-medium{font-size:19px}.elementor-widget-heading .elementor-heading-title.elementor-size-large{font-size:29px}.elementor-widget-heading .elementor-heading-title.elementor-size-xl{font-size:39px}.elementor-widget-heading .elementor-heading-title.elementor-size-xxl{font-size:59px}</style>\n<h2>Already Purchased This Course?</h2>\n<p><a href=\"https://carsi.com.au/courses/introduction-to-water-damage-restoration/lessons/introduction-to-water-damage-restoration/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Health and Safety</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Inspecting Water Damage</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Controlling Moisture Sources</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Water Extraction Methods</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Drying Equipment and Set Up</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\nThis course covers foundational aspects of water damage restoration, including health and safety practices, the use of Personal Protective Equipment (PPE), and safety hazards at water damage sites.\nParticipants learn to inspect and categorise water damage, control moisture sources, and use drying equipment.\nThe curriculum also includes cleaning and deodorising techniques, concluding with participants gaining essential knowledge and practical skills for successful water damage restoration.\nCourse Duration:\nApproximately 30 minutes\nContinuing Education Credit:\n\nThis course is approved for IICRC Continuing Education Credit (CEC): 1 Hour.\nOnce completed please email  support@carsi.com.au  for your Certification of completion confirming your hours of Continuing Education Credits.\n\n \nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
+    "short_description": "What can you expect from this Course?\nThis course covers foundational aspects of water damage restoration, including health and safety practices, the use of Personal Protective Equipment (PPE), and safety hazards at water damage sites.\nParticipants learn to inspect and categorise water damage, control moisture sources, and use drying equipment.\nThe curriculum also includes cleaning and deodorising techniques, concluding with participants gaining essential knowledge and practical skills for successful water damage restoration.\nCourse Duration:\nApproximately 30 minutes\nContinuing Education Credit:\n\nThis course is approved for IICRC Continuing Education Credit (CEC): 1 Hour.\nOnce completed please email\u00a0 support@carsi.com.au\u00a0 for your Certification of completion confirming your hours of Continuing Education Credits.\n\n \nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2023/12/water-damage-restoration-1.png",
     "status": "published",
     "price_aud": 29,
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": "WRT",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -2673,7 +2673,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -2741,12 +2741,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": "WRT",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -2754,7 +2754,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -2835,7 +2835,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -2878,12 +2878,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": "WRT",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -2891,7 +2891,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -2937,19 +2937,19 @@
     "slug": "water-damage-estimating-ccw",
     "title": "Introduction to Water Damage Estimating - CCW",
     "description": "<style>/*! elementor - v3.18.0 - 20-12-2023 */<br />.elementor-heading-title{padding:0;margin:0;line-height:1}.elementor-widget-heading .elementor-heading-title[class*=elementor-size-]>a{color:inherit;font-size:inherit;line-height:inherit}.elementor-widget-heading .elementor-heading-title.elementor-size-small{font-size:15px}.elementor-widget-heading .elementor-heading-title.elementor-size-medium{font-size:19px}.elementor-widget-heading .elementor-heading-title.elementor-size-large{font-size:29px}.elementor-widget-heading .elementor-heading-title.elementor-size-xl{font-size:39px}.elementor-widget-heading .elementor-heading-title.elementor-size-xxl{font-size:59px}</style>\n<h2>Already Purchased This Course?</h2>\n<p><a href=\"https://carsi.com.au/courses/introduction-to-water-damage-estimating/lessons/introduction-to-water-damage-estimating/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Assessment</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Scope Development</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Quantification</li>\n<li>Insurance Estimating</li>\n<li>Bid Analysis</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\nThis course aims to provide a comprehensive understanding of water damage assessment, covering categorization, damage documentation, identification of affected materials, and loss timeline considerations. Scope development encompasses drying, remediation, structural repairs, and contents manipulation, with quantification involving measurements, unit costs, overhead factors, and equipment/labor tally.\nThe course also delves into insurance estimating, bid analysis, collapsing estimates, and qualification statements.\nThis course concludes by ensuring participants can proficiently navigate the complexities of water damage assessment, from initial categorization to bid analysis and insurance estimating.\n \n \nCourse Duration:\nApproximately 30 minutes\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC): 1 Hour.\nOnce completed please email support@carsi.com.au for your Certification of completion confirming your hours of Continuing Education Credits.\n\n \nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
+    "short_description": "What can you expect from this Course?\n\nThis course aims to provide a comprehensive understanding of water damage assessment, covering categorization, damage documentation, identification of affected materials, and loss timeline considerations. Scope development encompasses drying, remediation, structural repairs, and contents manipulation, with quantification involving measurements, unit costs, overhead factors, and equipment/labor tally.\nThe course also delves into insurance estimating, bid analysis, collapsing estimates, and qualification statements.\nThis course concludes by ensuring participants can proficiently navigate the complexities of water damage assessment, from initial categorization to bid analysis and insurance estimating.\n\u00a0\n \nCourse Duration:\nApproximately 30 minutes\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC): 1 Hour.\nOnce completed please email support@carsi.com.au for your Certification of completion confirming your hours of Continuing Education Credits.\n\n \nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2023/12/water-damage-estimating-1.png",
     "status": "published",
     "price_aud": 29,
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": "WRT",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -2957,7 +2957,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -3025,12 +3025,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -3038,7 +3038,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -3091,7 +3091,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
@@ -3104,7 +3104,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -3172,12 +3172,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": "ASD",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -3185,7 +3185,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -3251,7 +3251,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -3289,7 +3289,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
@@ -3302,7 +3302,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -3360,12 +3360,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": "WRT",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -3373,7 +3373,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -3431,7 +3431,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
@@ -3444,7 +3444,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -3497,12 +3497,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": "ASD",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -3510,7 +3510,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -3581,7 +3581,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -3629,12 +3629,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": "ASD",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -3642,7 +3642,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -3700,12 +3700,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": "OCT",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -3713,7 +3713,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -3781,12 +3781,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -3794,7 +3794,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -3852,7 +3852,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
@@ -3865,7 +3865,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -3928,7 +3928,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
@@ -3941,7 +3941,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -4007,7 +4007,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -4070,12 +4070,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": "ASD",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -4083,7 +4083,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -4131,7 +4131,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
@@ -4144,7 +4144,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -4220,7 +4220,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -4296,7 +4296,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -4349,7 +4349,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
@@ -4362,7 +4362,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -4410,7 +4410,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
@@ -4423,7 +4423,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -4476,7 +4476,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
@@ -4489,7 +4489,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -4547,12 +4547,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": "CCT",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -4560,7 +4560,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -4623,12 +4623,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": "ASD",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -4636,7 +4636,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -4694,7 +4694,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
@@ -4707,7 +4707,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -4760,7 +4760,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
@@ -4773,7 +4773,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -4826,12 +4826,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": "ASD",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -4839,7 +4839,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -4902,7 +4902,7 @@
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -4915,7 +4915,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -4966,19 +4966,19 @@
     "slug": "infectious-control-for-the-business-owner-ccw",
     "title": "Infectious Control for the Business Owner - CCW",
     "description": "<style>/*! elementor - v3.13.1 - 09-05-2023 */<br />.elementor-heading-title{padding:0;margin:0;line-height:1}.elementor-widget-heading .elementor-heading-title[class*=elementor-size-]>a{color:inherit;font-size:inherit;line-height:inherit}.elementor-widget-heading .elementor-heading-title.elementor-size-small{font-size:15px}.elementor-widget-heading .elementor-heading-title.elementor-size-medium{font-size:19px}.elementor-widget-heading .elementor-heading-title.elementor-size-large{font-size:29px}.elementor-widget-heading .elementor-heading-title.elementor-size-xl{font-size:39px}.elementor-widget-heading .elementor-heading-title.elementor-size-xxl{font-size:59px}</style>\n<h2>Already Purchased This Course?</h2>\n<p><a role=\"button\" href=\"/courses/infectious-control-for-the-business-owner/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Virus Facts</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Bacteria and Modes of Transmission</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Cleaning and Disinfecting for Health</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Hygiene Practices</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Understanding Risks</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Cleaning Types and Touch Points</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Cross Contamination</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Insurance and Liability</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Before the Job</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Hazard Identification</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Risk Assessments</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Hierarchy of Controls</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Safety Data Sheets</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Labelling</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Standard Operating Procedures</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Job Safety and Environmental Analysis (JSEA)</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Safe Work Method Statements (SWMS)</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">ATP Terminology</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Hygiene Monitoring</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">ATP and Protocols</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Testing Protocols</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Examples</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Handling and Storage</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Chemicals</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Hazardous Chemicals</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Tools</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Application</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Microfiber Cloths</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Personal Protective Equipment PPE</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Donning and Doffing PPE</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Heat Exhaustion and Heat Stroke</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Disposal</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Quiz</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\nCleaners are essential workers and require increased training and knowledge in health cleaning. However, before you endeavor down the infectious control cleaning path, you need to ensure you and your business are prepared.\nStudy any time, anywhere, any pace, with Australia’s only CFO (Certified Forensic Operator) and CBFRS (Certified Bio-Forensic Restoration Specialist) Phillip McGurk, this course has been developed to educate cleaning companies of their requirements before they say yes to infectious control cleans.\nThe course follows strict local, national, and international legislation developed for the real-world cleaner.\nCourse Duration:\nApproximately 6.5 Hours\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC) : 7 Hours\nOnce completed please email support@carsi.com.au for your Certificate of completion confirming your hours of Continuing Education Credits.\n\n\nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
+    "short_description": "What can you expect from this Course?\nCleaners are essential workers and require increased training and knowledge in health cleaning. However, before you endeavor down the infectious control cleaning path, you need to ensure you and your business are prepared.\nStudy any time, anywhere, any pace, with Australia\u2019s only CFO (Certified Forensic Operator) and CBFRS (Certified Bio-Forensic Restoration Specialist) Phillip McGurk, this course has been developed to educate cleaning companies of their requirements before they say yes to infectious control cleans.\nThe course follows strict local, national, and international legislation developed for the real-world cleaner.\nCourse Duration:\nApproximately 6.5 Hours\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC) : 7 Hours\nOnce completed please email support@carsi.com.au for your Certificate of completion confirming your hours of Continuing Education Credits.\n\n\nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2021/02/BUSINESS-OWNER.png",
     "status": "published",
     "price_aud": 275,
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 7.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -4986,7 +4986,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -5037,19 +5037,19 @@
     "slug": "infection-control-in-child-care-ccw",
     "title": "Infection Control in Child Care - CCW",
     "description": "<style>/*! elementor - v3.13.1 - 09-05-2023 */<br />.elementor-heading-title{padding:0;margin:0;line-height:1}.elementor-widget-heading .elementor-heading-title[class*=elementor-size-]>a{color:inherit;font-size:inherit;line-height:inherit}.elementor-widget-heading .elementor-heading-title.elementor-size-small{font-size:15px}.elementor-widget-heading .elementor-heading-title.elementor-size-medium{font-size:19px}.elementor-widget-heading .elementor-heading-title.elementor-size-large{font-size:29px}.elementor-widget-heading .elementor-heading-title.elementor-size-xl{font-size:39px}.elementor-widget-heading .elementor-heading-title.elementor-size-xxl{font-size:59px}</style>\n<h2>Already Purchased This Course?</h2>\n<p><a role=\"button\" href=\"/courses/infection-control-in-child-care/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Virus Facts</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Bacteria and Modes of Transmission</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Cleaning and Disinfecting for Health</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Cross Contamination</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Hygiene Practices</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">When to Wash Hands</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Alcohol Based Hand Rub</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Gloves</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Cleaning Types and Touch Points</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Safe and Effective Disinfecting</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Using Products Safely</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Safety Data Sheets</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Labelling</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Microfiber Cloths</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Soft Surfaces</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Electronics</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Laundry</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Outdoor Areas</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Toys</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Nappy Changes</li>\n<li>Food Preparation and Handling</li>\n<li>Washing, Feeding and Holding Children</li>\n<li>Quiz</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\nChild Care Centres are receiving a lot of questions from parents in regard to providing a safe environment for the children they care for and require increased training and knowledge in health cleaning. It is now more important than ever that you realise the enormous responsibility and reliance on your skills and knowledge.\nStudy any time, anywhere, any pace, with Australia’s only CFO (Certified Forensic Operator) and CBFRS (Certified Bio-Forensic Restoration Specialist) Phillip McGurk, this course has been developed with specific details for infectious control cleaning within a Child Care Environment and is suited to those needing to understand the intricate details including microbe cleaning within this unique Environment.\nCourse Duration:\nApproximately 3 Hours\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC) : 3 Hours\nOnce completed please email support@carsi.com.au for your Certificate of completion confirming your hours of Continuing Education Credits.\n\n \n\nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.\n \n \n \n \nCheck out our other Infectious Cleaning Courses!:\nInfectious Control Cleaning &#8211; Carsi",
+    "short_description": "What can you expect from this Course?\nChild Care Centres are receiving a lot of questions from parents in regard to providing a safe environment for the children they care for and require increased training and knowledge in health cleaning. It is now more important than ever that you realise the enormous responsibility and reliance on your skills and knowledge.\nStudy any time, anywhere, any pace, with Australia\u2019s only CFO (Certified Forensic Operator) and CBFRS (Certified Bio-Forensic Restoration Specialist) Phillip McGurk, this course has been developed with specific details for infectious control cleaning within a Child Care Environment and is suited to those needing to understand the intricate details including microbe cleaning within this unique Environment.\nCourse Duration:\nApproximately 3 Hours\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC) : 3 Hours\nOnce completed please email support@carsi.com.au for your Certificate of completion confirming your hours of Continuing Education Credits.\n\n \n\nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.\n \n \n \n \nCheck out our other Infectious Cleaning Courses!:\nInfectious Control Cleaning &#8211; Carsi",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2021/02/CHILD-CARE.png",
     "status": "published",
     "price_aud": 99,
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 3.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -5057,7 +5057,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -5115,7 +5115,7 @@
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -5128,7 +5128,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -5181,12 +5181,12 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -5194,7 +5194,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -5252,7 +5252,7 @@
       "team"
     ],
     "iicrc_discipline": "CCT",
-    "cec_hours": null,
+    "cec_hours": 3.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -5265,7 +5265,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -5321,19 +5321,19 @@
     "slug": "asthmaallergy-ccw",
     "title": "Asthma and Allergy Course - CCW x CARSI",
     "description": "<style>/*! elementor - v3.13.1 - 09-05-2023 */<br />.elementor-heading-title{padding:0;margin:0;line-height:1}.elementor-widget-heading .elementor-heading-title[class*=elementor-size-]>a{color:inherit;font-size:inherit;line-height:inherit}.elementor-widget-heading .elementor-heading-title.elementor-size-small{font-size:15px}.elementor-widget-heading .elementor-heading-title.elementor-size-medium{font-size:19px}.elementor-widget-heading .elementor-heading-title.elementor-size-large{font-size:29px}.elementor-widget-heading .elementor-heading-title.elementor-size-xl{font-size:39px}.elementor-widget-heading .elementor-heading-title.elementor-size-xxl{font-size:59px}</style>\n<h2>Already Purchased This Course?</h2>\n<p><a role=\"button\" href=\"/courses/asthma-and-allergy-course/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Asthma and Allergies</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Asthma and Allergy Facts</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">The Relationship Between Allergic Diseases</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Dust Mite Allergies</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Pet Allergies</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Control and Prevention</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Environmental Control</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Anti Allergen Technology</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">How it Works</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Handling and Storage</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Safety Data Sheets</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Labelling</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Personal Protective Equipment PPE</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Donning and Doffing PPE</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Heat Exhaustion and Heat Stroke</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">The Anti Allergen Process</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Recommended Environmental Control Procedures</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Master Blend Product Range</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Disposal</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Documentation</li>\n<li>Standard Operating Procedures</li>\n<li>Marketing Opportunities</li>\n<li>Unique Selling Points</li>\n<li>Guarantees</li>\n<li>Return on Investments</li>\n</ul>\n<p style=\"margin: 0in; font-family: Calibri; font-size: 13.5pt;\">\n",
-    "short_description": "What can you expect from this Course?\nThe professional cleaning industry is able to perform an important and valuable service for those suffering from asthma and allergies. Find out HOW with CARSI&#8217;s Asthma and Allergy Course!\nExpand your business and services with an affordable new product out on the market!\nOur CEO Phill McGurk has done extensive research and training for the MasterBlend ResponsibleCare Stystem.  If you are thinking of using or already are using the MasterBlend ResponsibleCare System, this training package will expand your knowledge and give you confidence in understanding the chemicals and how to use them.\nCourse Duration:\nApproximately 5 Hours\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC) : 6 Hours\nOnce completed please email support@carsi.com.au for your Certificate of completion confirming your hours of Continuing Education Credits.\n\n\nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
+    "short_description": "What can you expect from this Course?\nThe professional cleaning industry is able to perform an important and valuable service for those suffering from asthma and allergies. Find out HOW with CARSI&#8217;s Asthma and Allergy Course!\nExpand your business and services with an affordable new product out on the market!\nOur CEO Phill McGurk has done extensive research and training for the MasterBlend ResponsibleCare Stystem.\u00a0 If you are thinking of using or already are using the MasterBlend ResponsibleCare System, this training package will expand your knowledge and give you confidence in understanding the chemicals and how to use them.\nCourse Duration:\nApproximately 5 Hours\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC) : 6 Hours\nOnce completed please email support@carsi.com.au for your Certificate of completion confirming your hours of Continuing Education Credits.\n\n\nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2021/02/ASTHMA-AND-ALLERGY.png",
     "status": "published",
     "price_aud": 129,
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 6.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -5341,7 +5341,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -5394,7 +5394,7 @@
       "team"
     ],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 4.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -5407,7 +5407,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -5475,7 +5475,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [
       "team"
     ],
@@ -5488,7 +5488,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -5531,7 +5531,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "ASD",
     "cec_hours": null,
@@ -5542,7 +5542,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -5579,7 +5579,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "WRT",
     "cec_hours": null,
@@ -5590,7 +5590,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -5630,14 +5630,14 @@
     "slug": "difficult-materials",
     "title": "Introduction to Drying Difficult Materials",
     "description": "<style>/*! elementor - v3.21.0 - 26-05-2024 */<br />.elementor-heading-title{padding:0;margin:0;line-height:1}.elementor-widget-heading .elementor-heading-title[class*=elementor-size-]>a{color:inherit;font-size:inherit;line-height:inherit}.elementor-widget-heading .elementor-heading-title.elementor-size-small{font-size:15px}.elementor-widget-heading .elementor-heading-title.elementor-size-medium{font-size:19px}.elementor-widget-heading .elementor-heading-title.elementor-size-large{font-size:29px}.elementor-widget-heading .elementor-heading-title.elementor-size-xl{font-size:39px}.elementor-widget-heading .elementor-heading-title.elementor-size-xxl{font-size:59px}</style>\n<h2>Already Purchased This Course?</h2>\n<p><a href=\"https://carsi.com.au/courses/introduction-to-drying-difficult-materials/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Dense Materials</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Composite Assemblies</li>\n<li>Irregular Geometries</li>\n<li>Delicate Contents</li>\n<li>Diffusion Dynamics</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\nThis course aims to provide an in-depth understanding of drying techniques for difficult materials.\nIt covers drying strategies for dense materials like concrete and plaster, composite assemblies such as insulated walls and carpeted floors, and irregular geometries including sculptures and musical instruments. Additionally, the course addresses the diffusion dynamics of moisture migration and evaporation rates, ensuring proper restoration and preservation practices.\n\n \n \nCourse Duration:\nApprox 30 Minutes\nCEC Credits\nTBA\n\n \nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.\n \n \n \n \nCheck out our other courses in the &#8216;Introduction Series&#8217;!:\nAll Courses | Explore CARSI’s Full Course Catalogue &#8211; Carsi",
+    "short_description": "What can you expect from this Course?\nThis course aims to provide an in-depth understanding of drying techniques for difficult materials.\nIt covers drying strategies for dense materials like concrete and plaster, composite assemblies such as insulated walls and carpeted floors, and irregular geometries including sculptures and musical instruments. Additionally, the course addresses the diffusion dynamics of moisture migration and evaporation rates, ensuring proper restoration and preservation practices.\n\n \n \nCourse Duration:\nApprox 30 Minutes\nCEC Credits\nTBA\n\n \nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.\n \n \n \n \nCheck out our other courses in the &#8216;Introduction Series&#8217;!:\nAll Courses | Explore CARSI\u2019s Full Course Catalogue &#8211; Carsi",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2024/06/Copy-of-Copy-of-Copy-of-Copy-of-Copy-of-Copy-of-drying-techniques-1-1.png",
     "status": "published",
     "price_aud": 29,
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "ASD",
     "cec_hours": null,
@@ -5648,7 +5648,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -5700,7 +5700,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "ASD",
     "cec_hours": null,
@@ -5711,7 +5711,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -5784,7 +5784,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -5847,7 +5847,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -5884,7 +5884,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "ASD",
     "cec_hours": null,
@@ -5895,7 +5895,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -5929,7 +5929,7 @@
   {
     "slug": "agi-smallbusiness",
     "title": "AGI Essentials: A Practical Guide for Small Business Success",
-    "description": "<style>/*! elementor - v3.21.0 - 30-04-2024 */<br />.elementor-heading-title{padding:0;margin:0;line-height:1}.elementor-widget-heading .elementor-heading-title[class*=elementor-size-]>a{color:inherit;font-size:inherit;line-height:inherit}.elementor-widget-heading .elementor-heading-title.elementor-size-small{font-size:15px}.elementor-widget-heading .elementor-heading-title.elementor-size-medium{font-size:19px}.elementor-widget-heading .elementor-heading-title.elementor-size-large{font-size:29px}.elementor-widget-heading .elementor-heading-title.elementor-size-xl{font-size:39px}.elementor-widget-heading .elementor-heading-title.elementor-size-xxl{font-size:59px}</style>\n<h1>Already Purchased This Course?</h1>\n<p><a href=\"https://carsi.com.au/courses/agi-essentials-a-practical-guide-for-small-business-success/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Background and understanding of AGI</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Introduction to AGI</li>\n<li>Understanding AI Basics</li>\n<li>AGI Applications for Small Business</li>\n<li>Implementing AGI in  Small Business</li>\n<li>Case Studies and Success Stories</li>\n<li>Future of AGI and Small Business</li>\n<li>Conclusion and Next Steps</li>\n</ul>\n</li>\n</ul>\n",
+    "description": "<style>/*! elementor - v3.21.0 - 30-04-2024 */<br />.elementor-heading-title{padding:0;margin:0;line-height:1}.elementor-widget-heading .elementor-heading-title[class*=elementor-size-]>a{color:inherit;font-size:inherit;line-height:inherit}.elementor-widget-heading .elementor-heading-title.elementor-size-small{font-size:15px}.elementor-widget-heading .elementor-heading-title.elementor-size-medium{font-size:19px}.elementor-widget-heading .elementor-heading-title.elementor-size-large{font-size:29px}.elementor-widget-heading .elementor-heading-title.elementor-size-xl{font-size:39px}.elementor-widget-heading .elementor-heading-title.elementor-size-xxl{font-size:59px}</style>\n<h1>Already Purchased This Course?</h1>\n<p><a href=\"https://carsi.com.au/courses/agi-essentials-a-practical-guide-for-small-business-success/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Background and understanding of AGI</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Introduction to AGI</li>\n<li>Understanding AI Basics</li>\n<li>AGI Applications for Small Business</li>\n<li>Implementing AGI in\u00a0 Small Business</li>\n<li>Case Studies and Success Stories</li>\n<li>Future of AGI and Small Business</li>\n<li>Conclusion and Next Steps</li>\n</ul>\n</li>\n</ul>\n",
     "short_description": "What can you expect from this Course?\nThis course aims to provide small business owners with a comprehensive understanding of Artificial General Intelligence (AGI) and its practical applications. Starting with an exploration of AGI fundamentals and its distinction from Narrow AI, the course delves into AGI&#8217;s potential to revolutionize various aspects of small businesses, including automation, customer service, marketing, data analysis, and financial management. Through a series of lessons, participants will learn about AGI implementation strategies, ethical considerations, and emerging trends, empowering them to leverage AGI effectively to drive innovation, efficiency, and growth within their businesses.\n \nCourse Duration:\nApprox 1 Hour",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2024/05/Copy-of-Copy-of-Copy-of-Copy-of-drying-techniques.png",
     "status": "published",
@@ -5953,7 +5953,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -5995,7 +5995,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "ASD",
     "cec_hours": null,
@@ -6006,7 +6006,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -6048,7 +6048,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
     "cec_hours": null,
@@ -6059,7 +6059,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -6106,7 +6106,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "ASD",
     "cec_hours": null,
@@ -6117,7 +6117,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -6180,7 +6180,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -6237,7 +6237,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
     "cec_hours": null,
@@ -6248,7 +6248,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -6300,7 +6300,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
     "cec_hours": null,
@@ -6311,7 +6311,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -6374,7 +6374,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -6432,7 +6432,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -6484,7 +6484,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "ASD",
     "cec_hours": null,
@@ -6495,7 +6495,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -6557,7 +6557,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
     "cec_hours": null,
@@ -6568,7 +6568,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -6636,7 +6636,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -6661,14 +6661,14 @@
     "slug": "duct-cleaning",
     "title": "Introduction to Residential Duct Cleaning",
     "description": "<style>/*! elementor - v3.18.0 - 20-12-2023 */<br />.elementor-heading-title{padding:0;margin:0;line-height:1}.elementor-widget-heading .elementor-heading-title[class*=elementor-size-]>a{color:inherit;font-size:inherit;line-height:inherit}.elementor-widget-heading .elementor-heading-title.elementor-size-small{font-size:15px}.elementor-widget-heading .elementor-heading-title.elementor-size-medium{font-size:19px}.elementor-widget-heading .elementor-heading-title.elementor-size-large{font-size:29px}.elementor-widget-heading .elementor-heading-title.elementor-size-xl{font-size:39px}.elementor-widget-heading .elementor-heading-title.elementor-size-xxl{font-size:59px}</style>\n<h2>Already Purchased This Course?</h2>\n<p><a href=\"https://carsi.com.au/shop/duct-cleaning/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">The Business of Residential Cleaning</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Understanding Residential HVAC Systems</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Contact Vs. Negative Pressure Duct Cleaning</li>\n<li>Negative Air Duct Cleaning Systems</li>\n<li>The Dust Master Contact Cleaning System</li>\n<li>Vent Vac Dryer Duct Cleaning System</li>\n<li>Cobra Power Brush Duct Cleaning System</li>\n<li>The Residential Duct Cleaning Process</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\n&#8220;The Business of Residential Cleaning&#8221; course provides a comprehensive guide to starting a successful duct cleaning business.\nCovering market research, target customer identification, licensing, insurance, marketing strategies, and customer education. It explores HVAC systems, duct cleaning methods, and equipment selection.\nThe course concludes with practical insights into specific cleaning systems and tools.This course prepares you for a successful venture into the residential cleaning business.\n \n \nCourse Duration:\nApproximately TBA\nContinuing Education Credit:\nTBA\n\n \nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
+    "short_description": "What can you expect from this Course?\n\n&#8220;The Business of Residential Cleaning&#8221; course provides a comprehensive guide to starting a successful duct cleaning business.\nCovering market research, target customer identification, licensing, insurance, marketing strategies, and customer education. It explores HVAC systems, duct cleaning methods, and equipment selection.\nThe course concludes with practical insights into specific cleaning systems and tools.This course prepares you for a successful venture into the residential cleaning business.\n\u00a0\n \nCourse Duration:\nApproximately TBA\nContinuing Education Credit:\nTBA\n\n \nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2023/12/DUCT-CLEANING.png",
     "status": "draft",
     "price_aud": 0,
     "is_free": true,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
     "cec_hours": null,
@@ -6679,7 +6679,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -6704,17 +6704,17 @@
     "slug": "water-damage-estimating",
     "title": "Introduction to Water Damage Estimating",
     "description": "<style>/*! elementor - v3.18.0 - 20-12-2023 */<br />.elementor-heading-title{padding:0;margin:0;line-height:1}.elementor-widget-heading .elementor-heading-title[class*=elementor-size-]>a{color:inherit;font-size:inherit;line-height:inherit}.elementor-widget-heading .elementor-heading-title.elementor-size-small{font-size:15px}.elementor-widget-heading .elementor-heading-title.elementor-size-medium{font-size:19px}.elementor-widget-heading .elementor-heading-title.elementor-size-large{font-size:29px}.elementor-widget-heading .elementor-heading-title.elementor-size-xl{font-size:39px}.elementor-widget-heading .elementor-heading-title.elementor-size-xxl{font-size:59px}</style>\n<h2>Already Purchased This Course?</h2>\n<p><a href=\"https://carsi.com.au/courses/introduction-to-water-damage-estimating/lessons/introduction-to-water-damage-estimating/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Assessment</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Scope Development</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Quantification</li>\n<li>Insurance Estimating</li>\n<li>Bid Analysis</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\n\nThis course aims to provide a comprehensive understanding of water damage assessment, covering categorization, damage documentation, identification of affected materials, and loss timeline considerations. Scope development encompasses drying, remediation, structural repairs, and contents manipulation, with quantification involving measurements, unit costs, overhead factors, and equipment/labor tally.\nThe course also delves into insurance estimating, bid analysis, collapsing estimates, and qualification statements.\nThis course concludes by ensuring participants can proficiently navigate the complexities of water damage assessment, from initial categorization to bid analysis and insurance estimating.\n \n \nCourse Duration:\nApproximately 30 minutes\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC): 1 Hour.\nOnce completed please email support@carsi.com.au for your Certification of completion confirming your hours of Continuing Education Credits.\n\n \nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
+    "short_description": "What can you expect from this Course?\n\nThis course aims to provide a comprehensive understanding of water damage assessment, covering categorization, damage documentation, identification of affected materials, and loss timeline considerations. Scope development encompasses drying, remediation, structural repairs, and contents manipulation, with quantification involving measurements, unit costs, overhead factors, and equipment/labor tally.\nThe course also delves into insurance estimating, bid analysis, collapsing estimates, and qualification statements.\nThis course concludes by ensuring participants can proficiently navigate the complexities of water damage assessment, from initial categorization to bid analysis and insurance estimating.\n\u00a0\n \nCourse Duration:\nApproximately 30 minutes\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC): 1 Hour.\nOnce completed please email support@carsi.com.au for your Certification of completion confirming your hours of Continuing Education Credits.\n\n \nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2023/12/water-damage-estimating-1.png",
     "status": "published",
     "price_aud": 29,
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "WRT",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -6722,7 +6722,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -6784,10 +6784,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "WRT",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -6795,7 +6795,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -6842,10 +6842,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "ASD",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -6853,7 +6853,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -6905,10 +6905,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "ASD",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -6916,7 +6916,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -6968,10 +6968,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "ASD",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -6979,7 +6979,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -7031,10 +7031,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "WRT",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -7042,7 +7042,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -7099,10 +7099,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "CCT",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -7110,7 +7110,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -7167,10 +7167,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "OCT",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -7178,7 +7178,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -7240,10 +7240,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "ASD",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -7251,7 +7251,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -7298,10 +7298,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "ASD",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -7309,7 +7309,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -7351,10 +7351,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "WRT",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -7362,7 +7362,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -7414,10 +7414,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "ASD",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -7425,7 +7425,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -7467,10 +7467,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -7478,7 +7478,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -7530,10 +7530,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -7541,7 +7541,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -7588,10 +7588,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "WRT",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -7599,7 +7599,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -7644,17 +7644,17 @@
     "slug": "introduction-to-water-damage-restoration-course",
     "title": "Introduction to Water Damage Restoration",
     "description": "<style>/*! elementor - v3.18.0 - 06-12-2023 */<br />.elementor-heading-title{padding:0;margin:0;line-height:1}.elementor-widget-heading .elementor-heading-title[class*=elementor-size-]>a{color:inherit;font-size:inherit;line-height:inherit}.elementor-widget-heading .elementor-heading-title.elementor-size-small{font-size:15px}.elementor-widget-heading .elementor-heading-title.elementor-size-medium{font-size:19px}.elementor-widget-heading .elementor-heading-title.elementor-size-large{font-size:29px}.elementor-widget-heading .elementor-heading-title.elementor-size-xl{font-size:39px}.elementor-widget-heading .elementor-heading-title.elementor-size-xxl{font-size:59px}</style>\n<h2>Already Purchased This Course?</h2>\n<p><a href=\"https://carsi.com.au/courses/introduction-to-water-damage-restoration/lessons/introduction-to-water-damage-restoration/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Health and Safety</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Inspecting Water Damage</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Controlling Moisture Sources</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Water Extraction Methods</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Drying Equipment and Set Up</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\nThis course covers foundational aspects of water damage restoration, including health and safety practices, the use of Personal Protective Equipment (PPE), and safety hazards at water damage sites.\nParticipants learn to inspect and categorise water damage, control moisture sources, and use drying equipment.\nThe curriculum also includes cleaning and deodorising techniques, concluding with participants gaining essential knowledge and practical skills for successful water damage restoration.\nCourse Duration:\nApproximately 30 minutes\nContinuing Education Credit:\n\nThis course is approved for IICRC Continuing Education Credit (CEC): 1 Hour.\nOnce completed please email  support@carsi.com.au  for your Certification of completion confirming your hours of Continuing Education Credits.\n\n \nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
+    "short_description": "What can you expect from this Course?\nThis course covers foundational aspects of water damage restoration, including health and safety practices, the use of Personal Protective Equipment (PPE), and safety hazards at water damage sites.\nParticipants learn to inspect and categorise water damage, control moisture sources, and use drying equipment.\nThe curriculum also includes cleaning and deodorising techniques, concluding with participants gaining essential knowledge and practical skills for successful water damage restoration.\nCourse Duration:\nApproximately 30 minutes\nContinuing Education Credit:\n\nThis course is approved for IICRC Continuing Education Credit (CEC): 1 Hour.\nOnce completed please email\u00a0 support@carsi.com.au\u00a0 for your Certification of completion confirming your hours of Continuing Education Credits.\n\n \nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2023/12/water-damage-restoration-1.png",
     "status": "published",
     "price_aud": 29,
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": "WRT",
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -7662,7 +7662,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -7724,7 +7724,7 @@
     "is_free": true,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
     "cec_hours": null,
@@ -7735,7 +7735,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -7772,7 +7772,7 @@
     "is_free": true,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
     "cec_hours": null,
@@ -7783,7 +7783,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -7820,7 +7820,7 @@
     "is_free": true,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
     "cec_hours": null,
@@ -7831,7 +7831,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -7873,7 +7873,7 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
     "cec_hours": null,
@@ -7884,7 +7884,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         }
       ],
@@ -7898,15 +7898,15 @@
   {
     "slug": "large-loss-mastery-course-split-payment",
     "title": "Large Loss Mastery Course Split Payment",
-    "description": "<p>Learn how to effectively apply the industry \"Best Practices\" when estimating and managing complex projects!<br />\n<strong>The Large Loss Mastery - <em>ELITE</em></strong> course offers hands-on, on-site simulations conducted at a location and city where an event has the potential to occur. The ELITE course gives the attendee the opportunity to be a part of a team that competes against other teams to win the simulated, commercial fire, water, flood or natural disaster loss. The projects simulated in LLM-E are complex events that require knowledge and expertise to successfully complete. LLM-E is designed to give the attendee the tools necessary and the hands-on experience to compete for any size property damage loss and complete them efficiently and effectively.<br />\n<strong>Large Loss Mastery -</strong> <strong><em>NEXT</em></strong>  Complex Project Management picks up where our <strong>Large Loss Mastery - ELITE</strong>  estimating and contracting course leaves off with a comprehensive approach to managing the job after winning the job.  The training event has hands-on case studies designed to provide the attendee with the knowledge of exactly how to manage commercial property loss opportunities and complete them efficiently and effectively.<br />\n<strong>What attendees learn:</strong>  damage assessment, estimating, scoping, contracting, vital document recovery, critical path planning, communications, documentation and audit triggers. Project Planning, Critical Path Plan creation and management, communication and documentation, Invoicing, audit triggers, health and safety, commercial sizing for drying and temporary climate control and managing scope changes.</p>\n",
-    "short_description": "CARSI is excited to bring you the Large Loss Mastery Course with Tom McGuire. We are thrilled to offer you the opportunity to attend this revolutionary course. Join us in Melbourne to learn how to effectively apply the industry “best practices” when estimating and managing complex projects!\nThe exclusive Large Loss Mastery Elite Course, spans over 3 days and offers exceptional accommodation recommendations, diverse case scenarios, thrilling activities, sightseeing opportunities, and unforgettable dining experiences. This event is a must-attend!",
+    "description": "<p>Learn how to effectively apply the industry \"Best Practices\" when estimating and managing complex projects!<br />\n<strong>The Large Loss Mastery - <em>ELITE</em></strong> course offers hands-on, on-site simulations conducted at a location and city where an event has the potential to occur. The ELITE course gives the attendee the opportunity to be a part of a team that competes against other teams to win the simulated, commercial fire, water, flood or natural disaster loss. The projects simulated in LLM-E are complex events that require knowledge and expertise to successfully complete. LLM-E is designed to give the attendee the tools necessary and the hands-on experience to compete for any size property damage loss and complete them efficiently and effectively.<br />\n<strong>Large Loss Mastery -</strong>\u00a0<strong><em>NEXT</em></strong>\u00a0 Complex Project Management picks up where our\u00a0<strong>Large Loss Mastery - ELITE</strong>\u00a0 estimating and contracting course leaves off with a comprehensive approach to managing the job after winning the job.\u00a0 The training event has hands-on case studies designed to provide the attendee with the knowledge of exactly how to manage commercial property loss opportunities and complete them efficiently and effectively.<br />\n<strong>What attendees learn:</strong>\u00a0 damage assessment, estimating, scoping, contracting, vital document recovery, critical path planning, communications, documentation and audit triggers. Project Planning, Critical Path Plan creation and management, communication and documentation, Invoicing, audit triggers, health and safety, commercial sizing for drying and temporary climate control and managing scope changes.</p>\n",
+    "short_description": "CARSI is excited to bring you the Large Loss Mastery Course with Tom McGuire. We are thrilled to offer you the opportunity to attend this revolutionary course. Join us in Melbourne to learn how to effectively apply the industry \u201cbest practices\u201d when estimating and managing complex projects!\nThe exclusive Large Loss Mastery Elite Course, spans over 3 days and offers exceptional accommodation recommendations, diverse case scenarios, thrilling activities, sightseeing opportunities, and unforgettable dining experiences. This event is a must-attend!",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2022/07/Facebook-LLM-post.png",
     "status": "draft",
     "price_aud": 1980,
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
     "cec_hours": null,
@@ -7917,7 +7917,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         }
       ],
@@ -7931,15 +7931,15 @@
   {
     "slug": "large-loss-mastery-super-course",
     "title": "Large Loss Mastery Course",
-    "description": "<p>https://youtu.be/wSw0PcN9-OMLearn how to effectively apply the industry \"Best Practices\" when estimating and managing complex projects!<br />\n<strong>The Large Loss Mastery - <em>ELITE</em></strong> course offers hands-on, on-site simulations conducted at a location and city where an event has the potential to occur. The ELITE course gives the attendee the opportunity to be a part of a team that competes against other teams to win the simulated, commercial fire, water, flood or natural disaster loss. The projects simulated in LLM-E are complex events that require knowledge and expertise to successfully complete. LLM-E is designed to give the attendee the tools necessary and the hands-on experience to compete for any size property damage loss and complete them efficiently and effectively.<br />\n<strong>Large Loss Mastery -</strong> <strong><em>NEXT</em></strong>  Complex Project Management picks up where our <strong>Large Loss Mastery - ELITE</strong>  estimating and contracting course leaves off with a comprehensive approach to managing the job after winning the job.  The training event has hands-on case studies designed to provide the attendee with the knowledge of exactly how to manage commercial property loss opportunities and complete them efficiently and effectively.<br />\n<strong>What attendees learn:</strong>  damage assessment, estimating, scoping, contracting, vital document recovery, critical path planning, communications, documentation and audit triggers. Project Planning, Critical Path Plan creation and management, communication and documentation, Invoicing, audit triggers, health and safety, commercial sizing for drying and temporary climate control and managing scope changes.</p>\n<p><img src=\"https://carsi.com.au/wp-content/uploads/2022/06/Things-to-Do-in-Sydney-3-1024x512.png\" sizes=\"(max-width: 1024px) 100vw, 1024px\" srcset=\"https://i0.wp.com/carsi.com.au/wp-content/uploads/2022/06/Things-to-Do-in-Sydney-3.png?resize=1024%2C512&amp;ssl=1 1024w, https://i0.wp.com/carsi.com.au/wp-content/uploads/2022/06/Things-to-Do-in-Sydney-3.png?resize=300%2C150&amp;ssl=1 300w, https://i0.wp.com/carsi.com.au/wp-content/uploads/2022/06/Things-to-Do-in-Sydney-3.png?resize=768%2C384&amp;ssl=1 768w, https://i0.wp.com/carsi.com.au/wp-content/uploads/2022/06/Things-to-Do-in-Sydney-3.png?resize=1536%2C768&amp;ssl=1 1536w, https://i0.wp.com/carsi.com.au/wp-content/uploads/2022/06/Things-to-Do-in-Sydney-3.png?resize=2048%2C1024&amp;ssl=1 2048w, https://i0.wp.com/carsi.com.au/wp-content/uploads/2022/06/Things-to-Do-in-Sydney-3.png?resize=600%2C300&amp;ssl=1 600w, https://i0.wp.com/carsi.com.au/wp-content/uploads/2022/06/Things-to-Do-in-Sydney-3.png?w=3000&amp;ssl=1 3000w\" alt=\"Novotel Accommodation\" width=\"1024\" height=\"512\" /><br />\n<a role=\"button\" href=\"https://www.idem.events/r/carsi-training-session-ac6de113\"><br />\nBook Accommodation<br />\n</a></p>\n",
-    "short_description": "CARSI is excited to bring you the Large Loss Mastery Course with Tom McGuire. We are thrilled to offer you the opportunity to attend this revolutionary course. Join us in Melbourne to learn how to effectively apply the industry “best practices” when estimating and managing complex projects!\nThe exclusive Large Loss Mastery Elite Course, spans over 3 days and offers exceptional accommodation recommendations, diverse case scenarios, thrilling activities, sightseeing opportunities, and unforgettable dining experiences. This event is a must-attend!\nSimply purchase a ticket via our fast track Eventbrite option below, or visit our official Eventbrite sales page\nhttps://www.eventbrite.com.au/e/large-loss-mastery-with-tom-mcguire-tickets-461594550727?utm-campaign=social&utm-content=attendeeshare&utm-medium=discovery&utm-term=listing&utm-source=cp&aff=escb",
+    "description": "<p>https://youtu.be/wSw0PcN9-OMLearn how to effectively apply the industry \"Best Practices\" when estimating and managing complex projects!<br />\n<strong>The Large Loss Mastery - <em>ELITE</em></strong> course offers hands-on, on-site simulations conducted at a location and city where an event has the potential to occur. The ELITE course gives the attendee the opportunity to be a part of a team that competes against other teams to win the simulated, commercial fire, water, flood or natural disaster loss. The projects simulated in LLM-E are complex events that require knowledge and expertise to successfully complete. LLM-E is designed to give the attendee the tools necessary and the hands-on experience to compete for any size property damage loss and complete them efficiently and effectively.<br />\n<strong>Large Loss Mastery -</strong>\u00a0<strong><em>NEXT</em></strong>\u00a0 Complex Project Management picks up where our\u00a0<strong>Large Loss Mastery - ELITE</strong>\u00a0 estimating and contracting course leaves off with a comprehensive approach to managing the job after winning the job.\u00a0 The training event has hands-on case studies designed to provide the attendee with the knowledge of exactly how to manage commercial property loss opportunities and complete them efficiently and effectively.<br />\n<strong>What attendees learn:</strong>\u00a0 damage assessment, estimating, scoping, contracting, vital document recovery, critical path planning, communications, documentation and audit triggers. Project Planning, Critical Path Plan creation and management, communication and documentation, Invoicing, audit triggers, health and safety, commercial sizing for drying and temporary climate control and managing scope changes.</p>\n<p><img src=\"https://carsi.com.au/wp-content/uploads/2022/06/Things-to-Do-in-Sydney-3-1024x512.png\" sizes=\"(max-width: 1024px) 100vw, 1024px\" srcset=\"https://i0.wp.com/carsi.com.au/wp-content/uploads/2022/06/Things-to-Do-in-Sydney-3.png?resize=1024%2C512&amp;ssl=1 1024w, https://i0.wp.com/carsi.com.au/wp-content/uploads/2022/06/Things-to-Do-in-Sydney-3.png?resize=300%2C150&amp;ssl=1 300w, https://i0.wp.com/carsi.com.au/wp-content/uploads/2022/06/Things-to-Do-in-Sydney-3.png?resize=768%2C384&amp;ssl=1 768w, https://i0.wp.com/carsi.com.au/wp-content/uploads/2022/06/Things-to-Do-in-Sydney-3.png?resize=1536%2C768&amp;ssl=1 1536w, https://i0.wp.com/carsi.com.au/wp-content/uploads/2022/06/Things-to-Do-in-Sydney-3.png?resize=2048%2C1024&amp;ssl=1 2048w, https://i0.wp.com/carsi.com.au/wp-content/uploads/2022/06/Things-to-Do-in-Sydney-3.png?resize=600%2C300&amp;ssl=1 600w, https://i0.wp.com/carsi.com.au/wp-content/uploads/2022/06/Things-to-Do-in-Sydney-3.png?w=3000&amp;ssl=1 3000w\" alt=\"Novotel Accommodation\" width=\"1024\" height=\"512\" /><br />\n<a role=\"button\" href=\"https://www.idem.events/r/carsi-training-session-ac6de113\"><br />\nBook Accommodation<br />\n</a></p>\n",
+    "short_description": "CARSI is excited to bring you the Large Loss Mastery Course with Tom McGuire. We are thrilled to offer you the opportunity to attend this revolutionary course. Join us in Melbourne to learn how to effectively apply the industry \u201cbest practices\u201d when estimating and managing complex projects!\nThe exclusive Large Loss Mastery Elite Course, spans over 3 days and offers exceptional accommodation recommendations, diverse case scenarios, thrilling activities, sightseeing opportunities, and unforgettable dining experiences. This event is a must-attend!\nSimply purchase a ticket via our fast track Eventbrite option below, or visit our official Eventbrite sales page\nhttps://www.eventbrite.com.au/e/large-loss-mastery-with-tom-mcguire-tickets-461594550727?utm-campaign=social&utm-content=attendeeshare&utm-medium=discovery&utm-term=listing&utm-source=cp&aff=escb",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2022/07/Facebook-LLM-post.png",
     "status": "draft",
     "price_aud": 1980,
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
     "cec_hours": null,
@@ -7950,7 +7950,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -7980,7 +7980,7 @@
     "category": "Admin Courses | Essential Skills for Restoration Managers",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -7993,7 +7993,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -8032,7 +8032,7 @@
   {
     "slug": "fundamental-business-framework",
     "title": "Fundamental Business Framework",
-    "description": "<h3>Already Purchased This Product?</h3>\n<p>\t\t\t\t\t<a href=\"https://carsi.com.au/courses/fundamental-business-framework/\"><br />\n\t\t\t\t\t\t\t\t\tAccess FBF<br />\n\t\t\t\t\t</a></p>\n<p>Topics included are:</p>\n<ul>\n<li>Essentials - 11 Topics</li>\n<li>Getting Started - 14 Topics</li>\n<li>Hiring - 15 Topics</li>\n<li>Company Administration - 18 Topics </li>\n<li>Onboarding - 5 Topics</li>\n<li>Marketing - 8 Topics</li>\n<li>Training - 15 Topics</li>\n<li>Growth - 11 Topics</li>\n<li>Exit - 6 Topics</li>\n</ul>\n",
+    "description": "<h3>Already Purchased This Product?</h3>\n<p>\t\t\t\t\t<a href=\"https://carsi.com.au/courses/fundamental-business-framework/\"><br />\n\t\t\t\t\t\t\t\t\tAccess FBF<br />\n\t\t\t\t\t</a></p>\n<p>Topics included are:</p>\n<ul>\n<li>Essentials - 11 Topics</li>\n<li>Getting Started - 14 Topics</li>\n<li>Hiring - 15 Topics</li>\n<li>Company Administration - 18 Topics\u00a0</li>\n<li>Onboarding - 5 Topics</li>\n<li>Marketing - 8 Topics</li>\n<li>Training - 15 Topics</li>\n<li>Growth - 11 Topics</li>\n<li>Exit - 6 Topics</li>\n</ul>\n",
     "short_description": "What can you expect from this course Package?\nWelcome to the Fundamental Business Framework course package, where we delve deep into the essential pillars of successful business management.\nWhether you&#8217;re an aspiring entrepreneur, a seasoned small business owner, or a manager aiming to enhance your skills, this course is designed to provide you with the knowledge and tools necessary to thrive in today&#8217;s competitive business landscape.\nIn this comprehensive course package, we cover a wide range of topics essential for building, managing, and growing a successful enterprise.\nAre you ready to embark on a transformative journey towards mastering the fundamentals of business management?\nJoin us and unlock your potential for success!",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2022/04/FBF.png",
     "status": "published",
@@ -8056,7 +8056,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -8086,7 +8086,7 @@
     "category": "Admin Courses | Essential Skills for Restoration Managers",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -8099,7 +8099,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -8144,7 +8144,7 @@
     "category": "Admin Courses | Essential Skills for Restoration Managers",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -8157,7 +8157,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -8207,7 +8207,7 @@
     "category": "Admin Courses | Essential Skills for Restoration Managers",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -8220,7 +8220,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -8290,7 +8290,7 @@
     "category": "Admin Courses | Essential Skills for Restoration Managers",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -8303,7 +8303,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -8358,7 +8358,7 @@
     "category": "Admin Courses | Essential Skills for Restoration Managers",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -8371,7 +8371,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -8426,7 +8426,7 @@
     "slug": "risk-assessment-course",
     "title": "Risk Assessment Course",
     "description": "<style>/*! elementor - v3.12.2 - 23-04-2023 */<br />.elementor-heading-title{padding:0;margin:0;line-height:1}.elementor-widget-heading .elementor-heading-title[class*=elementor-size-]>a{color:inherit;font-size:inherit;line-height:inherit}.elementor-widget-heading .elementor-heading-title.elementor-size-small{font-size:15px}.elementor-widget-heading .elementor-heading-title.elementor-size-medium{font-size:19px}.elementor-widget-heading .elementor-heading-title.elementor-size-large{font-size:29px}.elementor-widget-heading .elementor-heading-title.elementor-size-xl{font-size:39px}.elementor-widget-heading .elementor-heading-title.elementor-size-xxl{font-size:59px}</style>\n<h2>Already Purchased This Course?</h2>\n<p><a role=\"button\" href=\"/courses/risk-assessment-course/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Introduction to WH&amp;S</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Hazards and Risks</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Hazard Identification</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Managing Risks</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Risk Matrix</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Job Safety and Environmental Analysis</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Safe Work Method Statements</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">WH&amp;S Communication and Consultation</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Quiz</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\nRisk Management is one of the most important aspects within an organisation. It is a LEGAL obligation under the Workplace Health and Safety Act that all staff are trained to manage WHS risks.\nCARSI&#8217;s Risk Assessment Course aims to improve the participants awareness and knowledge on managing risks. The objectives of this course include, increase awareness of the need to identify hazards, Improve the ability to identify hazards within the workplace, increase understanding of how to evaluate hazards and the associated risks and more.\nCourse Duration:\nApproximately 1.5 Hours\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC) : 2 Hours\nOnce completed please email support@carsi.com.au for your Certificate of completion confirming your hours of Continuing Education Credits.\n\n\nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
+    "short_description": "What can you expect from this Course?\nRisk Management is one of the most important aspects within an organisation. It is a\u00a0LEGAL\u00a0obligation under the Workplace Health and Safety Act that all staff are trained to manage WHS risks.\nCARSI&#8217;s Risk Assessment Course aims to improve the participants awareness and knowledge on managing risks. The objectives of this course include, increase awareness of the need to identify hazards, Improve the ability to identify hazards within the workplace, increase understanding of how to evaluate hazards and the associated risks and more.\nCourse Duration:\nApproximately 1.5 Hours\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC) : 2 Hours\nOnce completed please email support@carsi.com.au for your Certificate of completion confirming your hours of Continuing Education Credits.\n\n\nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2021/09/RISK-ASSESSMENT.png",
     "status": "published",
     "price_aud": 99,
@@ -8436,7 +8436,7 @@
     "category": "Admin Courses | Essential Skills for Restoration Managers",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 2.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -8449,7 +8449,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -8516,10 +8516,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 2.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -8527,7 +8527,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -8592,7 +8592,7 @@
     "category": "Admin Courses | Essential Skills for Restoration Managers",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 4.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -8605,7 +8605,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -8667,10 +8667,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 5.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -8678,7 +8678,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -8745,10 +8745,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 4.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -8756,7 +8756,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -8821,7 +8821,7 @@
     "category": "Admin Courses | Essential Skills for Restoration Managers",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 2.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -8834,7 +8834,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -8873,7 +8873,7 @@
   {
     "slug": "affiliate-membership",
     "title": "Affiliate Membership",
-    "description": "<p>Becoming an affiliate member of CARSI.</p>\n<p>Affiliate membership is open to Organisations involved in small to medium sized companies with an active interest on business development and growth.</p>\n<p>Applying to become an affiliate member recognises your involvement to CARSI members and guests.  The goal is to develop business, marketing, specialised fields, education awareness across the CARSI platform and all are welcome.  There will be numerous benefits to becoming a CARSI affiliate member including access to events, marketing materials, education, and experiencing a virtually un-tapped industry.</p>\n<p>We believe CARSI offers a platform to advance thinking, developing of new skills, fuel for fulfilment and leadership.  We believe that collaboration, accountability, learning, and professional standards are important to the growth of the cleaning and restoration industries.  We provide invaluable, cost-saving membership privileges to support each member.</p>\n",
+    "description": "<p>Becoming an affiliate member of CARSI.</p>\n<p>Affiliate membership is open to Organisations involved in small to medium sized companies with an active interest on business development and growth.</p>\n<p>Applying to become an affiliate member recognises your involvement to CARSI members and guests.\u00a0 The goal is to develop business, marketing, specialised fields, education awareness across the CARSI platform and all are welcome.\u00a0 There will be numerous benefits to becoming a CARSI affiliate member including access to events, marketing materials, education, and experiencing a virtually un-tapped industry.</p>\n<p>We believe CARSI offers a platform to advance thinking, developing of new skills, fuel for fulfilment and leadership.\u00a0 We believe that collaboration, accountability, learning, and professional standards are important to the growth of the cleaning and restoration industries.\u00a0 We provide invaluable, cost-saving membership privileges to support each member.</p>\n",
     "short_description": "Sign up for our yearly Affiliation Package of AU 220 dollars.\nUnder business consultants in the CARSI membership area is where your Business Name, Logo, and company blurb is displayed allowing our members constant access to your details.",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2021/04/HISTORY-2021-04-06T153308.009.png",
     "status": "draft",
@@ -8947,10 +8947,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -8958,7 +8958,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -9008,7 +9008,7 @@
     "category": "Admin Courses | Essential Skills for Restoration Managers",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 3.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -9021,7 +9021,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -9142,7 +9142,7 @@
     "category": "Admin Courses | Essential Skills for Restoration Managers",
     "tags": [],
     "iicrc_discipline": "CCT",
-    "cec_hours": null,
+    "cec_hours": 3.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -9155,7 +9155,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -9205,17 +9205,17 @@
     "slug": "asthmaallergy",
     "title": "Asthma and Allergy Course",
     "description": "<style>/*! elementor - v3.13.1 - 09-05-2023 */<br />.elementor-heading-title{padding:0;margin:0;line-height:1}.elementor-widget-heading .elementor-heading-title[class*=elementor-size-]>a{color:inherit;font-size:inherit;line-height:inherit}.elementor-widget-heading .elementor-heading-title.elementor-size-small{font-size:15px}.elementor-widget-heading .elementor-heading-title.elementor-size-medium{font-size:19px}.elementor-widget-heading .elementor-heading-title.elementor-size-large{font-size:29px}.elementor-widget-heading .elementor-heading-title.elementor-size-xl{font-size:39px}.elementor-widget-heading .elementor-heading-title.elementor-size-xxl{font-size:59px}</style>\n<h2>Already Purchased This Course?</h2>\n<p><a role=\"button\" href=\"/courses/asthma-and-allergy-course/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Asthma and Allergies</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Asthma and Allergy Facts</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">The Relationship Between Allergic Diseases</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Dust Mite Allergies</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Pet Allergies</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Control and Prevention</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Environmental Control</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Anti Allergen Technology</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">How it Works</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Handling and Storage</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Safety Data Sheets</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Labelling</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Personal Protective Equipment PPE</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Donning and Doffing PPE</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Heat Exhaustion and Heat Stroke</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">The Anti Allergen Process</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Recommended Environmental Control Procedures</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Master Blend Product Range</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Disposal</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Documentation</li>\n<li>Standard Operating Procedures</li>\n<li>Marketing Opportunities</li>\n<li>Unique Selling Points</li>\n<li>Guarantees</li>\n<li>Return on Investments</li>\n</ul>\n<p style=\"margin: 0in; font-family: Calibri; font-size: 13.5pt;\">\n",
-    "short_description": "What can you expect from this Course?\nThe professional cleaning industry is able to perform an important and valuable service for those suffering from asthma and allergies. Find out HOW with CARSI&#8217;s Asthma and Allergy Course!\nExpand your business and services with an affordable new product out on the market!\nOur CEO Phill McGurk has done extensive research and training for the MasterBlend ResponsibleCare Stystem.  If you are thinking of using or already are using the MasterBlend ResponsibleCare System, this training package will expand your knowledge and give you confidence in understanding the chemicals and how to use them.\nCourse Duration:\nApproximately 5 Hours\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC) : 6 Hours\nOnce completed please email support@carsi.com.au for your Certificate of completion confirming your hours of Continuing Education Credits.\n\n\nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.\n \n \n \n \nCheck out our other Infectious Control Cleaning Courses!:\nInfectious Control Cleaning &#8211; Carsi",
+    "short_description": "What can you expect from this Course?\nThe professional cleaning industry is able to perform an important and valuable service for those suffering from asthma and allergies. Find out HOW with CARSI&#8217;s Asthma and Allergy Course!\nExpand your business and services with an affordable new product out on the market!\nOur CEO Phill McGurk has done extensive research and training for the MasterBlend ResponsibleCare Stystem.\u00a0 If you are thinking of using or already are using the MasterBlend ResponsibleCare System, this training package will expand your knowledge and give you confidence in understanding the chemicals and how to use them.\nCourse Duration:\nApproximately 5 Hours\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC) : 6 Hours\nOnce completed please email support@carsi.com.au for your Certificate of completion confirming your hours of Continuing Education Credits.\n\n\nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.\n \n \n \n \nCheck out our other Infectious Control Cleaning Courses!:\nInfectious Control Cleaning &#8211; Carsi",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2021/02/ASTHMA-AND-ALLERGY.png",
     "status": "published",
     "price_aud": 129,
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 6.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -9223,7 +9223,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -9258,17 +9258,17 @@
     "slug": "infectious-control-for-the-business-owner",
     "title": "Infectious Control for the Business Owner",
     "description": "<style>/*! elementor - v3.13.1 - 09-05-2023 */<br />.elementor-heading-title{padding:0;margin:0;line-height:1}.elementor-widget-heading .elementor-heading-title[class*=elementor-size-]>a{color:inherit;font-size:inherit;line-height:inherit}.elementor-widget-heading .elementor-heading-title.elementor-size-small{font-size:15px}.elementor-widget-heading .elementor-heading-title.elementor-size-medium{font-size:19px}.elementor-widget-heading .elementor-heading-title.elementor-size-large{font-size:29px}.elementor-widget-heading .elementor-heading-title.elementor-size-xl{font-size:39px}.elementor-widget-heading .elementor-heading-title.elementor-size-xxl{font-size:59px}</style>\n<h2>Already Purchased This Course?</h2>\n<p><a role=\"button\" href=\"/courses/infectious-control-for-the-business-owner/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul>\n<li style=\"list-style-type: none;\">\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Virus Facts</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Bacteria and Modes of Transmission</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Cleaning and Disinfecting for Health</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Hygiene Practices</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Understanding Risks</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Cleaning Types and Touch Points</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Cross Contamination</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Insurance and Liability</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Before the Job</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Hazard Identification</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Risk Assessments</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Hierarchy of Controls</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Safety Data Sheets</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Labelling</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Standard Operating Procedures</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Job Safety and Environmental Analysis (JSEA)</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Safe Work Method Statements (SWMS)</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">ATP Terminology</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Hygiene Monitoring</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">ATP and Protocols</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Testing Protocols</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Examples</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Handling and Storage</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Chemicals</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Hazardous Chemicals</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Tools</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Application</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Microfiber Cloths</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Personal Protective Equipment PPE</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Donning and Doffing PPE</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Heat Exhaustion and Heat Stroke</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Disposal</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Quiz</li>\n</ul>\n</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\nCleaners are essential workers and require increased training and knowledge in health cleaning. However, before you endeavor down the infectious control cleaning path, you need to ensure you and your business are prepared.\nStudy any time, anywhere, any pace, with Australia’s only CFO (Certified Forensic Operator) and CBFRS (Certified Bio-Forensic Restoration Specialist) Phillip McGurk, this course has been developed to educate cleaning companies of their requirements before they say yes to infectious control cleans.\nThe course follows strict local, national, and international legislation developed for the real-world cleaner.\nCourse Duration:\nApproximately 6.5 Hours\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC) : 7 Hours\nOnce completed please email support@carsi.com.au for your Certificate of completion confirming your hours of Continuing Education Credits.\n\n\nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
+    "short_description": "What can you expect from this Course?\nCleaners are essential workers and require increased training and knowledge in health cleaning. However, before you endeavor down the infectious control cleaning path, you need to ensure you and your business are prepared.\nStudy any time, anywhere, any pace, with Australia\u2019s only CFO (Certified Forensic Operator) and CBFRS (Certified Bio-Forensic Restoration Specialist) Phillip McGurk, this course has been developed to educate cleaning companies of their requirements before they say yes to infectious control cleans.\nThe course follows strict local, national, and international legislation developed for the real-world cleaner.\nCourse Duration:\nApproximately 6.5 Hours\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC) : 7 Hours\nOnce completed please email support@carsi.com.au for your Certificate of completion confirming your hours of Continuing Education Credits.\n\n\nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2021/02/BUSINESS-OWNER.png",
     "status": "published",
     "price_aud": 275,
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 7.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -9276,7 +9276,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -9331,7 +9331,7 @@
     "category": "Admin Courses | Essential Skills for Restoration Managers",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 1.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -9344,7 +9344,7 @@
         },
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -9374,17 +9374,17 @@
     "slug": "infection-control-in-child-care",
     "title": "Infection Control in Child Care",
     "description": "<style>/*! elementor - v3.13.1 - 09-05-2023 */<br />.elementor-heading-title{padding:0;margin:0;line-height:1}.elementor-widget-heading .elementor-heading-title[class*=elementor-size-]>a{color:inherit;font-size:inherit;line-height:inherit}.elementor-widget-heading .elementor-heading-title.elementor-size-small{font-size:15px}.elementor-widget-heading .elementor-heading-title.elementor-size-medium{font-size:19px}.elementor-widget-heading .elementor-heading-title.elementor-size-large{font-size:29px}.elementor-widget-heading .elementor-heading-title.elementor-size-xl{font-size:39px}.elementor-widget-heading .elementor-heading-title.elementor-size-xxl{font-size:59px}</style>\n<h2>Already Purchased This Course?</h2>\n<p><a role=\"button\" href=\"/courses/infection-control-in-child-care/\"><br />\nAccess Here<br />\n</a></p>\n<p style=\"margin: 0in; margin-left: .375in; font-family: Calibri; font-size: 13.5pt;\">Topics covered include:</p>\n<ul style=\"direction: ltr; unicode-bidi: embed; margin-top: 0in; margin-bottom: 0in;\" type=\"disc\">\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Virus Facts</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Bacteria and Modes of Transmission</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Cleaning and Disinfecting for Health</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Cross Contamination</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Hygiene Practices</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">When to Wash Hands</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Alcohol Based Hand Rub</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Gloves</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Cleaning Types and Touch Points</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Safe and Effective Disinfecting</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Using Products Safely</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Safety Data Sheets</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Labelling</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Microfiber Cloths</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Soft Surfaces</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Electronics</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Laundry</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Outdoor Areas</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Toys</li>\n<li style=\"margin-top: 0; margin-bottom: 0; vertical-align: middle;\">Nappy Changes</li>\n<li>Food Preparation and Handling</li>\n<li>Washing, Feeding and Holding Children</li>\n<li>Quiz</li>\n</ul>\n",
-    "short_description": "What can you expect from this Course?\nChild Care Centres are receiving a lot of questions from parents in regard to providing a safe environment for the children they care for and require increased training and knowledge in health cleaning. It is now more important than ever that you realise the enormous responsibility and reliance on your skills and knowledge.\nStudy any time, anywhere, any pace, with Australia’s only CFO (Certified Forensic Operator) and CBFRS (Certified Bio-Forensic Restoration Specialist) Phillip McGurk, this course has been developed with specific details for infectious control cleaning within a Child Care Environment and is suited to those needing to understand the intricate details including microbe cleaning within this unique Environment.\nCourse Duration:\nApproximately 3 Hours\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC) : 3 Hours\nOnce completed please email support@carsi.com.au for your Certificate of completion confirming your hours of Continuing Education Credits.\n\n \n\nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
+    "short_description": "What can you expect from this Course?\nChild Care Centres are receiving a lot of questions from parents in regard to providing a safe environment for the children they care for and require increased training and knowledge in health cleaning. It is now more important than ever that you realise the enormous responsibility and reliance on your skills and knowledge.\nStudy any time, anywhere, any pace, with Australia\u2019s only CFO (Certified Forensic Operator) and CBFRS (Certified Bio-Forensic Restoration Specialist) Phillip McGurk, this course has been developed with specific details for infectious control cleaning within a Child Care Environment and is suited to those needing to understand the intricate details including microbe cleaning within this unique Environment.\nCourse Duration:\nApproximately 3 Hours\nContinuing Education Credit:\nThis course is approved for IICRC Continuing Education Credit (CEC) : 3 Hours\nOnce completed please email support@carsi.com.au for your Certificate of completion confirming your hours of Continuing Education Credits.\n\n \n\nThe IICRC does not endorse any educational provider, product, offering, \nor service. The Institute expressly disclaims responsibility, \nendorsement or warranty for third-party publications, \nproducts, certifications, or instruction. \nThe approved status does not award IICRC Certification, \nonly qualified continuing education hours.",
     "thumbnail_url": "https://carsi.com.au/wp-content/uploads/2021/02/CHILD-CARE.png",
     "status": "published",
     "price_aud": 99,
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 3.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -9392,7 +9392,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -9439,10 +9439,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 5.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -9450,7 +9450,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {
@@ -9502,10 +9502,10 @@
     "is_free": false,
     "duration_hours": null,
     "level": null,
-    "category": "All Courses | Explore CARSI’s Full Course Catalogue",
+    "category": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
     "tags": [],
     "iicrc_discipline": null,
-    "cec_hours": null,
+    "cec_hours": 5.0,
     "cppp40421_unit_code": null,
     "cppp40421_unit_name": null,
     "meta": {
@@ -9513,7 +9513,7 @@
       "wp_categories": [
         {
           "id": 43,
-          "name": "All Courses | Explore CARSI’s Full Course Catalogue",
+          "name": "All Courses | Explore CARSI\u2019s Full Course Catalogue",
           "slug": "view-all"
         },
         {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -77,6 +77,12 @@ const pwaConfig = withPWA({
 const nextConfig: NextConfig = {
   output: 'standalone',
   reactStrictMode: true,
+  async redirects() {
+    return [
+      { source: '/student', destination: '/dashboard/student', permanent: true },
+      { source: '/student/:path*', destination: '/dashboard/student/:path*', permanent: true },
+    ];
+  },
   typescript: {
     ignoreBuildErrors: false,
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "postinstall": "prisma generate",
     "build": "prisma generate && next build",
-    "dev": "next dev",
+    "dev": "prisma generate && prisma migrate deploy && next dev",
     "start": "prisma migrate deploy && next start",
     "start:with-course-seed": "prisma migrate deploy && npm run db:seed-courses && next start",
     "db:export-courses": "npx tsx scripts/export-courses-catalog.ts",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "db:export-courses": "npx tsx scripts/export-courses-catalog.ts",
     "db:seed-courses": "npx tsx scripts/seed-courses-catalog.ts",
     "db:seed-wp-export": "npx tsx scripts/seed-wordpress-export-courses.ts",
+    "db:enrich-wp-export-cec": "npx tsx scripts/enrich-wp-export-cec.ts",
+    "db:seed-cec-hours": "npx tsx scripts/seed-course-cec-hours.ts",
     "db:seed-wp-lessons": "npx tsx scripts/seed-wordpress-lessons-wxr.ts",
     "db:set-wp-export-draft": "npx tsx scripts/set-wp-export-courses-draft.ts",
     "db:export-draft-courses-wp": "npx tsx scripts/export-draft-courses-wp-dump.ts",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "postinstall": "prisma generate",
     "build": "prisma generate && next build",
-    "dev": "prisma generate && prisma migrate deploy && next dev",
+    "dev": "prisma generate && next dev",
+    "dev:with-migrate": "prisma generate && prisma migrate deploy && next dev",
     "start": "prisma migrate deploy && next start",
     "start:with-course-seed": "prisma migrate deploy && npm run db:seed-courses && next start",
     "db:export-courses": "npx tsx scripts/export-courses-catalog.ts",

--- a/prisma/migrations/20260521000000_team_course_slug/migration.sql
+++ b/prisma/migrations/20260521000000_team_course_slug/migration.sql
@@ -1,0 +1,2 @@
+-- Course purchased for team seats (per-course team checkout).
+ALTER TABLE "lms_teams" ADD COLUMN IF NOT EXISTS "course_slug" VARCHAR(128);

--- a/prisma/migrations/20260522100000_team_course_purchases/migration.sql
+++ b/prisma/migrations/20260522100000_team_course_purchases/migration.sql
@@ -1,0 +1,35 @@
+-- Per-course team seat purchases (multiple course checkouts per team).
+CREATE TABLE IF NOT EXISTS "lms_team_course_purchases" (
+    "id" UUID NOT NULL,
+    "team_id" UUID NOT NULL,
+    "course_slug" VARCHAR(128) NOT NULL,
+    "seat_limit" INTEGER NOT NULL,
+    "payment_reference" VARCHAR(255),
+    "purchased_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "lms_team_course_purchases_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "lms_team_course_purchases_team_id_idx" ON "lms_team_course_purchases"("team_id");
+CREATE INDEX IF NOT EXISTS "lms_team_course_purchases_course_slug_idx" ON "lms_team_course_purchases"("course_slug");
+
+ALTER TABLE "lms_team_course_purchases"
+ADD CONSTRAINT "lms_team_course_purchases_team_id_fkey"
+FOREIGN KEY ("team_id") REFERENCES "lms_teams"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Backfill from legacy single course_slug + seat_limit on team.
+INSERT INTO "lms_team_course_purchases" ("id", "team_id", "course_slug", "seat_limit", "payment_reference", "purchased_at")
+SELECT
+    gen_random_uuid(),
+    t."id",
+    t."course_slug",
+    t."seat_limit",
+    NULL,
+    t."created_at"
+FROM "lms_teams" t
+WHERE t."bundle_tier" = 'course_purchase'
+  AND t."course_slug" IS NOT NULL
+  AND t."course_slug" <> ''
+  AND NOT EXISTS (
+    SELECT 1 FROM "lms_team_course_purchases" p WHERE p."team_id" = t."id" AND p."course_slug" = t."course_slug"
+  );

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -287,15 +287,33 @@ model LmsTeam {
   slug         String   @unique
   ownerId      String   @map("owner_id") @db.Uuid
   bundleTier   String   @map("bundle_tier") @db.VarChar(32)
+  courseSlug   String?  @map("course_slug") @db.VarChar(128)
   seatLimit    Int      @default(5) @map("seat_limit")
   createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt    DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  owner   LmsUser         @relation("TeamOwner", fields: [ownerId], references: [id], onDelete: Cascade)
-  members LmsTeamMember[]
-  invites LmsTeamInvite[]
+  owner            LmsUser                @relation("TeamOwner", fields: [ownerId], references: [id], onDelete: Cascade)
+  members          LmsTeamMember[]
+  invites          LmsTeamInvite[]
+  coursePurchases  LmsTeamCoursePurchase[]
 
   @@map("lms_teams")
+}
+
+/// Seats purchased for a specific course on a team (one row per team checkout).
+model LmsTeamCoursePurchase {
+  id                String   @id @default(uuid()) @db.Uuid
+  teamId            String   @map("team_id") @db.Uuid
+  courseSlug        String   @map("course_slug") @db.VarChar(128)
+  seatLimit         Int      @map("seat_limit")
+  paymentReference  String?  @map("payment_reference") @db.VarChar(255)
+  purchasedAt       DateTime @default(now()) @map("purchased_at") @db.Timestamptz(6)
+
+  team LmsTeam @relation(fields: [teamId], references: [id], onDelete: Cascade)
+
+  @@index([teamId])
+  @@index([courseSlug])
+  @@map("lms_team_course_purchases")
 }
 
 model LmsTeamMember {

--- a/public/sw.js
+++ b/public/sw.js
@@ -5,7 +5,11 @@ const CACHE_NAME = 'carsi-v2';
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) =>
-      cache.addAll(['/', '/courses', '/dashboard/student']),
+      Promise.all(
+        ['/', '/courses', '/dashboard/student'].map((url) =>
+          cache.add(url).catch((e) => console.warn('[sw] precache skip', url, e)),
+        ),
+      ),
     ),
   );
   self.skipWaiting();

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,10 +1,12 @@
 // CARSI LMS Service Worker — PWA + Push Notifications
-const CACHE_NAME = 'carsi-v1';
+const CACHE_NAME = 'carsi-v2';
 
-// Install — cache critical shell assets
+// Install — cache critical shell assets (valid routes only)
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(['/', '/courses', '/student']))
+    caches.open(CACHE_NAME).then((cache) =>
+      cache.addAll(['/', '/courses', '/dashboard/student']),
+    ),
   );
   self.skipWaiting();
 });
@@ -15,25 +17,38 @@ self.addEventListener('activate', (event) => {
     caches
       .keys()
       .then((keys) =>
-        Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
-      )
+        Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k))),
+      ),
   );
   self.clients.claim();
 });
 
-// Fetch — network-first, cache fallback
+// Fetch — do not intercept document navigations (avoids broken HTML streams in dev)
 self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') return;
-  event.respondWith(fetch(event.request).catch(() => caches.match(event.request)));
+  if (event.request.mode === 'navigate') return;
+
+  const url = new URL(event.request.url);
+  if (url.origin !== self.location.origin) return;
+
+  event.respondWith(
+    fetch(event.request).catch(() => caches.match(event.request)),
+  );
 });
 
 // Push — show notification
 self.addEventListener('push', (event) => {
-  let data = { title: 'CARSI', body: 'You have a new notification.', url: '/student' };
+  let data = {
+    title: 'CARSI',
+    body: 'You have a new notification.',
+    url: '/dashboard/student',
+  };
   if (event.data) {
     try {
       data = JSON.parse(event.data.text());
-    } catch (_) {}
+    } catch (_) {
+      /* ignore */
+    }
   }
   event.waitUntil(
     self.registration.showNotification(data.title, {
@@ -43,14 +58,15 @@ self.addEventListener('push', (event) => {
       data: { url: data.url },
       tag: 'carsi-notification',
       renotify: true,
-    })
+    }),
   );
 });
 
 // Notification click — open app
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
-  const url = event.notification.data?.url ?? '/student';
+  const raw = event.notification.data?.url ?? '/dashboard/student';
+  const url = raw === '/student' || raw.startsWith('/student/') ? `/dashboard${raw}` : raw;
   event.waitUntil(
     clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
       for (const client of clientList) {
@@ -60,6 +76,6 @@ self.addEventListener('notificationclick', (event) => {
         }
       }
       if (clients.openWindow) return clients.openWindow(url);
-    })
+    }),
   );
 });

--- a/scripts/enrich-wp-export-cec.ts
+++ b/scripts/enrich-wp-export-cec.ts
@@ -1,0 +1,42 @@
+/**
+ * Fill `cec_hours` on `data/wordpress-export/courses.json` from meta + description text.
+ *
+ *   npm run db:enrich-wp-export-cec
+ *   npm run db:enrich-wp-export-cec -- --dry-run
+ *
+ * Optional: WP_EXPORT_COURSES_PATH=/abs/path/to/courses.json
+ */
+import 'dotenv/config';
+
+import { writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { enrichCourseWithCecHours } from '../src/lib/seed/cec-hours';
+import type { WpExportCourseRow } from '../src/lib/seed/wp-export-published-import-slugs';
+import { readWpExportCoursesJsonOrThrow, resolveWpExportCoursesJsonPath } from '../src/lib/seed/wp-export-courses-json';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const APP_ROOT = join(__dirname, '..');
+const dryRun = process.argv.includes('--dry-run');
+
+const raw = readWpExportCoursesJsonOrThrow(APP_ROOT);
+const courses = JSON.parse(raw) as WpExportCourseRow[];
+const enriched = courses.map((c) => enrichCourseWithCecHours(c));
+
+const hadBefore = courses.filter((c) => c.cec_hours != null).length;
+const hasAfter = enriched.filter((c) => c.cec_hours != null).length;
+const newlySet = enriched.filter((c, i) => c.cec_hours != null && courses[i]?.cec_hours == null).length;
+
+console.log(`Courses: ${courses.length}`);
+console.log(`cec_hours before: ${hadBefore} set`);
+console.log(`cec_hours after:  ${hasAfter} set (+${newlySet} from text/meta)`);
+
+if (dryRun) {
+  console.log('Dry run — file not written.');
+  process.exit(0);
+}
+
+const outPath = resolveWpExportCoursesJsonPath(APP_ROOT);
+writeFileSync(outPath, `${JSON.stringify(enriched, null, 2)}\n`, 'utf8');
+console.log(`Wrote ${outPath}`);

--- a/scripts/resolve-pr-review-threads.mjs
+++ b/scripts/resolve-pr-review-threads.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * Resolve all unresolved GitHub PR review threads (e.g. CodeRabbit).
+ *
+ * Usage:
+ *   GITHUB_TOKEN=ghp_... node scripts/resolve-pr-review-threads.mjs 158
+ *   gh auth token | xargs -I{} env GITHUB_TOKEN={} node scripts/resolve-pr-review-threads.mjs 158
+ */
+const owner = process.env.GITHUB_OWNER || 'CleanExpo';
+const repo = process.env.GITHUB_REPO || 'CARSI';
+const prNumber = Number(process.argv[2] || process.env.PR_NUMBER || '158');
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+
+if (!token?.trim()) {
+  console.error('Set GITHUB_TOKEN or GH_TOKEN (e.g. gh auth token).');
+  process.exit(1);
+}
+
+async function graphql(query, variables = {}) {
+  const res = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = await res.json();
+  if (!res.ok || json.errors) {
+    throw new Error(JSON.stringify(json.errors || json, null, 2));
+  }
+  return json.data;
+}
+
+const listQuery = `
+  query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        reviewThreads(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes { id isResolved }
+        }
+      }
+    }
+  }
+`;
+
+const resolveMutation = `
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: { threadId: $threadId }) {
+      thread { id isResolved }
+    }
+  }
+`;
+
+async function listUnresolvedThreads() {
+  const threads = [];
+  let cursor = null;
+  for (;;) {
+    const data = await graphql(listQuery, {
+      owner,
+      repo,
+      number: prNumber,
+      cursor,
+    });
+    const batch = data.repository.pullRequest.reviewThreads;
+    for (const t of batch.nodes) {
+      if (!t.isResolved) threads.push(t.id);
+    }
+    if (!batch.pageInfo.hasNextPage) break;
+    cursor = batch.pageInfo.endCursor;
+  }
+  return threads;
+}
+
+async function main() {
+  const ids = await listUnresolvedThreads();
+  if (ids.length === 0) {
+    console.log(`PR #${prNumber}: no unresolved review threads.`);
+    return;
+  }
+  console.log(`Resolving ${ids.length} thread(s) on ${owner}/${repo}#${prNumber}...`);
+  for (const id of ids) {
+    await graphql(resolveMutation, { threadId: id });
+    console.log('  resolved', id);
+  }
+  console.log('Done.');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/seed-course-cec-hours.ts
+++ b/scripts/seed-course-cec-hours.ts
@@ -30,13 +30,17 @@ const APP_ROOT = join(__dirname, '..');
 const dryRun = process.argv.includes('--dry-run');
 const overwrite = process.argv.includes('--overwrite');
 
+function normalizeSlug(slug: string): string {
+  return slug.trim().toLowerCase();
+}
+
 function buildCecBySlug(): Map<string, number> {
   const map = new Map<string, number>();
 
   const wpRaw = readWpExportCoursesJsonOrThrow(APP_ROOT);
   const allWp = JSON.parse(wpRaw) as WpExportCourseRow[];
   for (const row of allWp.map((c) => enrichCourseWithCecHours(c))) {
-    if (row.cec_hours != null) map.set(row.slug, row.cec_hours);
+    if (row.cec_hours != null) map.set(normalizeSlug(row.slug), row.cec_hours);
   }
 
   const catalogPath = join(APP_ROOT, 'data', 'seed', 'courses-catalog.json');
@@ -44,13 +48,13 @@ function buildCecBySlug(): Map<string, number> {
   if (isCoursesCatalogFile(catalog)) {
     for (const c of catalog.courses) {
       const hours = resolveCatalogCecHours(c);
-      if (hours != null) map.set(c.slug, hours);
+      if (hours != null) map.set(normalizeSlug(c.slug), hours);
     }
   }
 
   const { rows } = getPublishedWpImportRows(APP_ROOT);
   for (const row of rows.map((c) => enrichCourseWithCecHours(c))) {
-    if (row.cec_hours != null) map.set(row.slug, row.cec_hours);
+    if (row.cec_hours != null) map.set(normalizeSlug(row.slug), row.cec_hours);
   }
 
   return map;
@@ -69,7 +73,7 @@ async function main() {
   let missing = 0;
 
   for (const course of courses) {
-    const hours = cecBySlug.get(course.slug);
+    const hours = cecBySlug.get(normalizeSlug(course.slug));
     if (hours == null) {
       missing++;
       continue;

--- a/scripts/seed-course-cec-hours.ts
+++ b/scripts/seed-course-cec-hours.ts
@@ -1,0 +1,113 @@
+/**
+ * Update `lms_courses.cec_hours` from WP export (+ catalog text) where a value is known.
+ *
+ *   DATABASE_URL="..." npm run db:seed-cec-hours
+ *   npm run db:seed-cec-hours -- --overwrite   # replace existing non-null values too
+ *   npm run db:seed-cec-hours -- --dry-run
+ *
+ * Sources (in order per slug):
+ * 1. Published WP export rows (enriched with resolveCecHours)
+ * 2. `data/seed/courses-catalog.json` courses (text/meta when cecHours null)
+ */
+import 'dotenv/config';
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { prisma } from '../src/lib/prisma';
+import { enrichCourseWithCecHours, resolveCatalogCecHours } from '../src/lib/seed/cec-hours';
+import { isCoursesCatalogFile } from '../src/lib/seed/courses-catalog-types';
+import {
+  getPublishedWpImportRows,
+  type WpExportCourseRow,
+} from '../src/lib/seed/wp-export-published-import-slugs';
+import { readWpExportCoursesJsonOrThrow } from '../src/lib/seed/wp-export-courses-json';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const APP_ROOT = join(__dirname, '..');
+
+const dryRun = process.argv.includes('--dry-run');
+const overwrite = process.argv.includes('--overwrite');
+
+function buildCecBySlug(): Map<string, number> {
+  const map = new Map<string, number>();
+
+  const wpRaw = readWpExportCoursesJsonOrThrow(APP_ROOT);
+  const allWp = JSON.parse(wpRaw) as WpExportCourseRow[];
+  for (const row of allWp.map((c) => enrichCourseWithCecHours(c))) {
+    if (row.cec_hours != null) map.set(row.slug, row.cec_hours);
+  }
+
+  const catalogPath = join(APP_ROOT, 'data', 'seed', 'courses-catalog.json');
+  const catalog = JSON.parse(readFileSync(catalogPath, 'utf8')) as unknown;
+  if (isCoursesCatalogFile(catalog)) {
+    for (const c of catalog.courses) {
+      const hours = resolveCatalogCecHours(c);
+      if (hours != null) map.set(c.slug, hours);
+    }
+  }
+
+  const { rows } = getPublishedWpImportRows(APP_ROOT);
+  for (const row of rows.map((c) => enrichCourseWithCecHours(c))) {
+    if (row.cec_hours != null) map.set(row.slug, row.cec_hours);
+  }
+
+  return map;
+}
+
+async function main() {
+  const cecBySlug = buildCecBySlug();
+  console.log(`Resolved CEC for ${cecBySlug.size} slug(s) from export/catalog.`);
+
+  const courses = await prisma.lmsCourse.findMany({
+    select: { id: true, slug: true, title: true, cecHours: true },
+  });
+
+  let updated = 0;
+  let skipped = 0;
+  let missing = 0;
+
+  for (const course of courses) {
+    const hours = cecBySlug.get(course.slug);
+    if (hours == null) {
+      missing++;
+      continue;
+    }
+
+    const current =
+      course.cecHours != null ? Number(course.cecHours) : null;
+
+    if (!overwrite && current != null && Number.isFinite(current)) {
+      skipped++;
+      continue;
+    }
+
+    if (current === hours) {
+      skipped++;
+      continue;
+    }
+
+    if (!dryRun) {
+      await prisma.lmsCourse.update({
+        where: { id: course.id },
+        data: { cecHours: hours },
+      });
+    }
+    updated++;
+    console.log(`  ${course.slug}: ${current ?? '—'} → ${hours}`);
+  }
+
+  console.log(
+    dryRun
+      ? `Dry run: would update ${updated}, skip ${skipped}, no source for ${missing} DB row(s).`
+      : `Updated ${updated}, skipped ${skipped}, no source for ${missing} DB row(s).`
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/seed-courses-catalog.ts
+++ b/scripts/seed-courses-catalog.ts
@@ -25,6 +25,7 @@ import { prisma } from '../src/lib/prisma';
 type PrismaTx = Parameters<Parameters<typeof prisma.$transaction>[0]>[0];
 import type { CatalogCourse, CoursesCatalogFile } from '../src/lib/seed/courses-catalog-types';
 import { COURSES_CATALOG_VERSION, isCoursesCatalogFile } from '../src/lib/seed/courses-catalog-types';
+import { resolveCatalogCecHours } from '../src/lib/seed/cec-hours';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CATALOG_PATH = join(__dirname, '..', 'data', 'seed', 'courses-catalog.json');
@@ -79,6 +80,7 @@ async function deleteCourseCurriculum(tx: PrismaTx, courseId: string) {
 
 async function seedCourse(c: CatalogCourse, instructorOverride: string | undefined) {
   const instructorId = instructorOverride?.trim() || c.instructorId;
+  const cecHours = c.cecHours ?? resolveCatalogCecHours(c);
 
   await prisma.$transaction(async (tx) => {
     const existing = await tx.lmsCourse.findUnique({
@@ -109,7 +111,7 @@ async function seedCourse(c: CatalogCourse, instructorOverride: string | undefin
         category: c.category,
         tags: jsonInput(c.tags),
         iicrcDiscipline: c.iicrcDiscipline,
-        cecHours: c.cecHours,
+        cecHours,
         meta: jsonInput(c.meta),
         isPublished: c.isPublished,
         modules: {
@@ -145,7 +147,7 @@ async function seedCourse(c: CatalogCourse, instructorOverride: string | undefin
         category: c.category,
         tags: jsonInput(c.tags),
         iicrcDiscipline: c.iicrcDiscipline,
-        cecHours: c.cecHours,
+        cecHours,
         meta: jsonInput(c.meta),
         isPublished: c.isPublished,
       },

--- a/scripts/wp-migrate.ts
+++ b/scripts/wp-migrate.ts
@@ -23,6 +23,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { resolveCecHours } from '../src/lib/seed/cec-hours';
+
 // ============================================================================
 // Configuration
 // ============================================================================
@@ -255,19 +257,6 @@ function detectIICRCDiscipline(categories: string[], title: string): string | nu
   return null;
 }
 
-function extractCECHours(metaData: Array<{ key: string; value: unknown }>): number | null {
-  // Look for CEC-related meta fields
-  const cecKeys = ['cec_hours', '_cec_hours', 'iicrc_cec', 'continuing_education_credits'];
-
-  for (const meta of metaData) {
-    if (cecKeys.includes(meta.key.toLowerCase())) {
-      const val = parseFloat(String(meta.value));
-      if (!isNaN(val)) return val;
-    }
-  }
-
-  return null;
-}
 
 // ============================================================================
 // WordPress API Fetchers
@@ -552,7 +541,12 @@ function transformToLMSCourses(products: WPProduct[], categories: WPCategory[]):
       tags: tagNames,
       iicrc_discipline:
         product.course_data?.iicrc_discipline || detectIICRCDiscipline(categoryNames, product.name),
-      cec_hours: product.course_data?.cec_hours || extractCECHours(product.meta_data) || null,
+      cec_hours: resolveCecHours({
+        cec_hours: product.course_data?.cec_hours ?? null,
+        short_description: stripHTML(product.short_description),
+        description: product.description,
+        meta: product.meta_data,
+      }),
       cppp40421_unit_code: null,
       cppp40421_unit_name: null,
       meta: {

--- a/src/components/admin/AdminCourseMultiPicker.tsx
+++ b/src/components/admin/AdminCourseMultiPicker.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Search, X } from 'lucide-react';
+
+import type { AdminCatalogCourseOption } from '@/lib/admin/admin-user-progress';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+export function AdminCourseMultiPicker({
+  courses,
+  enrolledSlugs,
+  selectedSlugs,
+  onSelectionChange,
+  disabled,
+}: {
+  courses: AdminCatalogCourseOption[];
+  enrolledSlugs: Set<string>;
+  selectedSlugs: Set<string>;
+  onSelectionChange: (slugs: Set<string>) => void;
+  disabled?: boolean;
+}) {
+  const [query, setQuery] = useState('');
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return courses;
+    return courses.filter(
+      (c) => c.title.toLowerCase().includes(q) || c.slug.toLowerCase().includes(q),
+    );
+  }, [courses, query]);
+
+  const grantableCount = useMemo(
+    () => courses.filter((c) => !enrolledSlugs.has(c.slug)).length,
+    [courses, enrolledSlugs],
+  );
+
+  const selectedCourses = useMemo(
+    () => courses.filter((c) => selectedSlugs.has(c.slug)),
+    [courses, selectedSlugs],
+  );
+
+  function toggle(slug: string) {
+    if (enrolledSlugs.has(slug) || disabled) return;
+    const next = new Set(selectedSlugs);
+    if (next.has(slug)) next.delete(slug);
+    else next.add(slug);
+    onSelectionChange(next);
+  }
+
+  function selectAllGrantable() {
+    if (disabled) return;
+    const next = new Set(selectedSlugs);
+    for (const c of courses) {
+      if (!enrolledSlugs.has(c.slug)) next.add(c.slug);
+    }
+    onSelectionChange(next);
+  }
+
+  function clearSelection() {
+    if (disabled) return;
+    onSelectionChange(new Set());
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="relative">
+        <Search className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-white/35" />
+        <Input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search courses by title…"
+          disabled={disabled || grantableCount === 0}
+          className="h-11 rounded-xl border-white/10 bg-white/[0.04] pl-10 text-white placeholder:text-white/35"
+          aria-label="Search courses"
+        />
+      </div>
+
+      {selectedCourses.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {selectedCourses.map((c) => (
+            <button
+              key={c.slug}
+              type="button"
+              disabled={disabled}
+              onClick={() => toggle(c.slug)}
+              className="inline-flex max-w-full items-center gap-1.5 rounded-full border border-[#2490ed]/35 bg-[#2490ed]/15 px-2.5 py-1 text-left text-xs font-medium text-[#93c5fd] transition-colors hover:bg-[#2490ed]/25 disabled:opacity-50"
+            >
+              <span className="truncate">{c.title}</span>
+              <X className="h-3 w-3 shrink-0 opacity-70" aria-hidden />
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-white/45">
+        <span>
+          {grantableCount} available · {courses.length} in catalog
+          {query.trim() ? ` · ${filtered.length} shown` : ''}
+        </span>
+        <span className="flex gap-2">
+          <button
+            type="button"
+            className="font-medium text-[#7ec5ff] hover:text-white disabled:opacity-40"
+            disabled={disabled || grantableCount === 0}
+            onClick={selectAllGrantable}
+          >
+            Select all available
+          </button>
+          {selectedSlugs.size > 0 ? (
+            <button
+              type="button"
+              className="font-medium text-white/55 hover:text-white disabled:opacity-40"
+              disabled={disabled}
+              onClick={clearSelection}
+            >
+              Clear
+            </button>
+          ) : null}
+        </span>
+      </div>
+
+      <div
+        className={cn(
+          'max-h-[min(320px,45vh)] overflow-y-auto rounded-xl border border-white/[0.08] bg-black/25',
+          disabled && 'pointer-events-none opacity-60',
+        )}
+        role="listbox"
+        aria-label="Course catalog"
+        aria-multiselectable="true"
+      >
+        {filtered.length === 0 ? (
+          <p className="px-4 py-8 text-center text-sm text-white/45">No courses match your search.</p>
+        ) : (
+          <ul className="divide-y divide-white/[0.05]">
+            {filtered.map((c) => {
+              const enrolled = enrolledSlugs.has(c.slug);
+              const checked = enrolled || selectedSlugs.has(c.slug);
+              return (
+                <li key={c.slug}>
+                  <label
+                    className={cn(
+                      'flex cursor-pointer items-start gap-3 px-4 py-3 transition-colors',
+                      enrolled ? 'cursor-not-allowed bg-white/[0.02] opacity-55' : 'hover:bg-white/[0.04]',
+                      !enrolled && selectedSlugs.has(c.slug) && 'bg-[#2490ed]/10',
+                    )}
+                  >
+                    <input
+                      type="checkbox"
+                      className="mt-1 h-4 w-4 shrink-0 rounded border-white/20 bg-white/5 accent-[#2490ed]"
+                      checked={checked}
+                      disabled={enrolled || disabled}
+                      onChange={() => toggle(c.slug)}
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-sm font-medium leading-snug text-white/90">{c.title}</span>
+                      <span className="mt-0.5 block text-xs text-white/42">
+                        {c.moduleCount} modules
+                        {enrolled ? ' · Already enrolled' : ''}
+                      </span>
+                    </span>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/AdminUserDetailClient.tsx
+++ b/src/components/admin/AdminUserDetailClient.tsx
@@ -607,8 +607,14 @@ export function AdminUserDetailClient({
                     pendingRevoke={pendingRevokeId === e.enrollmentId}
                     pendingComplete={pendingCompleteIds.has(e.enrollmentId)}
                     onToggleSelect={() => toggleEnrollmentSelection(e.enrollmentId)}
-                    onRevoke={(id) => void revokeEnrollment(id)}
-                    onMarkComplete={(id) => void markEnrollmentsComplete([id])}
+                    onRevoke={
+                      bulkCompletePending ? () => {} : (id) => void revokeEnrollment(id)
+                    }
+                    onMarkComplete={
+                      bulkCompletePending
+                        ? () => {}
+                        : (id) => void markEnrollmentsComplete([id])
+                    }
                   />
                 );
               })}

--- a/src/components/admin/AdminUserDetailClient.tsx
+++ b/src/components/admin/AdminUserDetailClient.tsx
@@ -31,16 +31,10 @@ import {
   LearnerAvatar,
   StatusBadge,
 } from '@/components/admin/admin-learner-ui';
+import { AdminCourseMultiPicker } from '@/components/admin/AdminCourseMultiPicker';
 import { ProgressBar } from '@/components/lms/ProgressBar';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { cn } from '@/lib/utils';
 
 const chartTooltipProps = {
@@ -56,23 +50,47 @@ const chartTooltipProps = {
 function CourseEnrollmentCard({
   enrollment,
   pendingRevoke,
+  pendingComplete,
+  selectable,
+  selected,
+  onToggleSelect,
   onRevoke,
+  onMarkComplete,
 }: {
   enrollment: AdminCourseProgressForUser;
   pendingRevoke: boolean;
+  pendingComplete: boolean;
+  selectable: boolean;
+  selected: boolean;
+  onToggleSelect: () => void;
   onRevoke: (id: string) => void;
+  onMarkComplete: (id: string) => void;
 }) {
   const statusLabel = enrollment.status.replace(/_/g, ' ');
+  const isComplete = enrollment.completionPct >= 100;
   return (
     <article
       className={cn(
         adminGlassCard,
         'overflow-hidden p-0',
-        enrollment.completionPct >= 100 && 'border-emerald-400/20',
+        isComplete && 'border-emerald-400/20',
+        selected && 'ring-1 ring-[#2490ed]/45',
       )}
     >
       <div className="border-b border-white/[0.06] px-5 py-4 sm:px-6">
         <div className="flex flex-wrap items-start justify-between gap-4">
+          {selectable ? (
+            <label className="flex cursor-pointer items-start gap-3 pt-1">
+              <input
+                type="checkbox"
+                checked={selected}
+                disabled={pendingComplete}
+                onChange={onToggleSelect}
+                className="mt-1 h-4 w-4 shrink-0 rounded border-white/20 bg-white/5 accent-[#2490ed]"
+                aria-label={`Select ${enrollment.courseTitle}`}
+              />
+            </label>
+          ) : null}
           <div className="min-w-0 flex-1 space-y-2">
             <div className="flex flex-wrap items-center gap-2">
               <StatusBadge label={statusLabel} tone={enrollmentStatusTone(enrollment.status)} />
@@ -104,19 +122,38 @@ function CourseEnrollmentCard({
               </div>
             </dl>
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center justify-end gap-2">
             <div
               className="text-2xl font-black tabular-nums"
               style={{ color: completionColor(enrollment.completionPct) }}
             >
               {enrollment.completionPct}%
             </div>
+            {!isComplete ? (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                className="h-9 rounded-lg border-white/10 bg-white/[0.06] text-white/85 hover:bg-white/10"
+                disabled={pendingComplete || pendingRevoke}
+                onClick={() => onMarkComplete(enrollment.enrollmentId)}
+              >
+                {pendingComplete ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <>
+                    <CheckCircle2 className="mr-1.5 h-3.5 w-3.5" />
+                    Mark complete
+                  </>
+                )}
+              </Button>
+            ) : null}
             <Button
               type="button"
               size="icon"
               variant="destructive"
               className="h-10 w-10 shrink-0 rounded-xl"
-              disabled={pendingRevoke}
+              disabled={pendingRevoke || pendingComplete}
               onClick={() => onRevoke(enrollment.enrollmentId)}
               title="Remove enrollment"
             >
@@ -173,14 +210,21 @@ export function AdminUserDetailClient({
   catalogCourses: AdminCatalogCourseOption[];
 }) {
   const router = useRouter();
-  const [courseSlugToAdd, setCourseSlugToAdd] = useState('');
+  const [selectedCourseSlugs, setSelectedCourseSlugs] = useState<Set<string>>(() => new Set());
   const [pendingGrant, setPendingGrant] = useState(false);
   const [pendingRevokeId, setPendingRevokeId] = useState<string | null>(null);
+  const [pendingCompleteIds, setPendingCompleteIds] = useState<Set<string>>(() => new Set());
+  const [selectedEnrollmentIds, setSelectedEnrollmentIds] = useState<Set<string>>(() => new Set());
   const [actionError, setActionError] = useState<string | null>(null);
 
+  const incompleteEnrollments = useMemo(
+    () => user.enrollments.filter((e) => e.completionPct < 100),
+    [user.enrollments],
+  );
+
   const enrolledSlugs = useMemo(() => new Set(user.enrollments.map((e) => e.courseSlug)), [user.enrollments]);
-  const grantableCourses = useMemo(
-    () => catalogCourses.filter((c) => !enrolledSlugs.has(c.slug)),
+  const grantableCount = useMemo(
+    () => catalogCourses.filter((c) => !enrolledSlugs.has(c.slug)).length,
     [catalogCourses, enrolledSlugs],
   );
 
@@ -198,22 +242,27 @@ export function AdminUserDetailClient({
 
   const displayName = user.fullName?.trim() || user.email.split('@')[0] || 'Learner';
 
-  async function grantCourse() {
+  async function grantSelectedCourses() {
     setActionError(null);
-    if (!courseSlugToAdd) return;
+    const slugs = [...selectedCourseSlugs].filter((s) => !enrolledSlugs.has(s));
+    if (slugs.length === 0) return;
     setPendingGrant(true);
     try {
       const res = await fetch('/api/admin/enrollments', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ studentId: user.userId, courseSlug: courseSlugToAdd }),
+        body: JSON.stringify({ studentId: user.userId, courseSlugs: slugs }),
       });
-      const payload = (await res.json().catch(() => ({}))) as { detail?: string };
+      const payload = (await res.json().catch(() => ({}))) as {
+        detail?: string;
+        created?: number;
+        alreadyEnrolled?: number;
+      };
       if (!res.ok) {
-        setActionError(payload.detail ?? 'Could not add course');
+        setActionError(payload.detail ?? 'Could not grant course access');
         return;
       }
-      setCourseSlugToAdd('');
+      setSelectedCourseSlugs(new Set());
       router.refresh();
     } finally {
       setPendingGrant(false);
@@ -230,11 +279,58 @@ export function AdminUserDetailClient({
         setActionError(payload.detail ?? 'Could not remove course');
         return;
       }
+      setSelectedEnrollmentIds((prev) => {
+        const next = new Set(prev);
+        next.delete(enrollmentId);
+        return next;
+      });
       router.refresh();
     } finally {
       setPendingRevokeId(null);
     }
   }
+
+  function toggleEnrollmentSelection(enrollmentId: string) {
+    setSelectedEnrollmentIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(enrollmentId)) next.delete(enrollmentId);
+      else next.add(enrollmentId);
+      return next;
+    });
+  }
+
+  function selectAllIncomplete() {
+    setSelectedEnrollmentIds(new Set(incompleteEnrollments.map((e) => e.enrollmentId)));
+  }
+
+  function clearSelection() {
+    setSelectedEnrollmentIds(new Set());
+  }
+
+  async function markEnrollmentsComplete(enrollmentIds: string[]) {
+    if (enrollmentIds.length === 0) return;
+    setActionError(null);
+    setPendingCompleteIds(new Set(enrollmentIds));
+    try {
+      const res = await fetch('/api/admin/enrollments/complete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ studentId: user.userId, enrollmentIds }),
+      });
+      const payload = (await res.json().catch(() => ({}))) as { detail?: string };
+      if (!res.ok) {
+        setActionError(payload.detail ?? 'Could not mark courses complete');
+        return;
+      }
+      setSelectedEnrollmentIds(new Set());
+      router.refresh();
+    } finally {
+      setPendingCompleteIds(new Set());
+    }
+  }
+
+  const bulkCompletePending = pendingCompleteIds.size > 0;
+  const selectedCount = selectedEnrollmentIds.size;
 
   return (
     <div className="relative px-5 py-8 pb-24 sm:px-8 sm:py-10">
@@ -409,69 +505,113 @@ export function AdminUserDetailClient({
                 <div>
                   <CardTitle className="text-base text-white/88">Course enrollments</CardTitle>
                   <CardDescription className="text-white/45">
-                    Assign catalog courses, review progress, and remove access
+                    Assign courses, mark completions for CEC support, or remove access
                   </CardDescription>
                 </div>
               </div>
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
-                <div className="min-w-0 flex-1 space-y-1.5">
+              <div className="space-y-3">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <div className="text-[10px] font-semibold tracking-[0.16em] text-white/38 uppercase">
-                    Add course
+                    Add courses
                   </div>
-                  <Select
-                    value={courseSlugToAdd}
-                    onValueChange={setCourseSlugToAdd}
-                    disabled={grantableCourses.length === 0}
+                  <Button
+                    type="button"
+                    className="h-10 shrink-0 rounded-xl px-5 font-semibold sm:self-start"
+                    disabled={selectedCourseSlugs.size === 0 || pendingGrant || grantableCount === 0}
+                    onClick={() => void grantSelectedCourses()}
                   >
-                    <SelectTrigger className="h-11 rounded-xl border-white/10 bg-white/[0.04]">
-                      <SelectValue
-                        placeholder={
-                          grantableCourses.length ? 'Choose a course…' : 'All catalog courses assigned'
-                        }
-                      />
-                    </SelectTrigger>
-                    <SelectContent
-                      className="z-[200] border-white/10 bg-[rgba(10,14,26,0.98)] text-white shadow-xl"
-                      position="popper"
-                      sideOffset={6}
-                    >
-                      {grantableCourses.map((c) => (
-                        <SelectItem
-                          key={c.slug}
-                          value={c.slug}
-                          className="items-start py-2.5 pr-9 pl-3 whitespace-normal focus:bg-white/10"
-                        >
-                          <span className="block leading-snug">
-                            {c.title}
-                            <span className="mt-0.5 block text-xs text-white/50">{c.moduleCount} modules</span>
-                          </span>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                    {pendingGrant ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      `Grant access${selectedCourseSlugs.size > 0 ? ` (${selectedCourseSlugs.size})` : ''}`
+                    )}
+                  </Button>
                 </div>
-                <Button
-                  type="button"
-                  className="h-11 shrink-0 rounded-xl px-6 font-semibold"
-                  disabled={!courseSlugToAdd || pendingGrant}
-                  onClick={() => void grantCourse()}
-                >
-                  {pendingGrant ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Grant access'}
-                </Button>
+                <AdminCourseMultiPicker
+                  courses={catalogCourses}
+                  enrolledSlugs={enrolledSlugs}
+                  selectedSlugs={selectedCourseSlugs}
+                  onSelectionChange={setSelectedCourseSlugs}
+                  disabled={pendingGrant || grantableCount === 0}
+                />
               </div>
             </CardHeader>
           </Card>
 
           {user.enrollments.length > 0 ? (
             <div className="space-y-5">
-              {user.enrollments.map((e) => (
-                <CourseEnrollmentCard
-                  key={e.enrollmentId}
-                  enrollment={e}
-                  pendingRevoke={pendingRevokeId === e.enrollmentId}
-                  onRevoke={(id) => void revokeEnrollment(id)}
-                />
-              ))}
+              {incompleteEnrollments.length > 0 ? (
+                <div
+                  className={cn(
+                    adminGlassCard,
+                    'flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between',
+                  )}
+                >
+                  <p className="text-sm text-white/55">
+                    {incompleteEnrollments.length} course
+                    {incompleteEnrollments.length === 1 ? '' : 's'} not fully complete
+                    {selectedCount > 0 ? (
+                      <span className="text-white/80"> · {selectedCount} selected</span>
+                    ) : null}
+                  </p>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-9 text-white/60 hover:text-white"
+                      disabled={bulkCompletePending}
+                      onClick={selectAllIncomplete}
+                    >
+                      Select all incomplete
+                    </Button>
+                    {selectedCount > 0 ? (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-9 text-white/60 hover:text-white"
+                        disabled={bulkCompletePending}
+                        onClick={clearSelection}
+                      >
+                        Clear
+                      </Button>
+                    ) : null}
+                    <Button
+                      type="button"
+                      size="sm"
+                      className="h-9 rounded-lg bg-[#2490ed] px-4 font-semibold hover:bg-[#1a7fd4]"
+                      disabled={selectedCount === 0 || bulkCompletePending}
+                      onClick={() => void markEnrollmentsComplete([...selectedEnrollmentIds])}
+                    >
+                      {bulkCompletePending ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <>
+                          <CheckCircle2 className="mr-1.5 h-4 w-4" />
+                          Mark {selectedCount > 0 ? selectedCount : ''} complete
+                        </>
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+              {user.enrollments.map((e) => {
+                const isIncomplete = e.completionPct < 100;
+                return (
+                  <CourseEnrollmentCard
+                    key={e.enrollmentId}
+                    enrollment={e}
+                    selectable={isIncomplete}
+                    selected={selectedEnrollmentIds.has(e.enrollmentId)}
+                    pendingRevoke={pendingRevokeId === e.enrollmentId}
+                    pendingComplete={pendingCompleteIds.has(e.enrollmentId)}
+                    onToggleSelect={() => toggleEnrollmentSelection(e.enrollmentId)}
+                    onRevoke={(id) => void revokeEnrollment(id)}
+                    onMarkComplete={(id) => void markEnrollmentsComplete([id])}
+                  />
+                );
+              })}
             </div>
           ) : (
             <div

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -86,6 +86,9 @@ export function LoginForm() {
     form.setValue('password', parsed.data.password, { shouldDirty: true });
 
     try {
+      const nextParam =
+        searchParams.get('next') ?? searchParams.get('redirect') ?? undefined;
+
       const response = await fetch('/api/auth/login', {
         method: 'POST',
         headers: {
@@ -94,10 +97,14 @@ export function LoginForm() {
         body: JSON.stringify({
           email: parsed.data.email,
           password: parsed.data.password,
+          next: nextParam,
         }),
       });
 
-      const data = await response.json();
+      const data = (await response.json()) as {
+        error?: string;
+        redirect_to?: string;
+      };
 
       if (!response.ok) {
         setError(data.error || 'Login failed');
@@ -106,13 +113,14 @@ export function LoginForm() {
         return;
       }
 
-      // Server-side login succeeded, cookies are set — redirect to next or student dashboard
-      const next =
-        searchParams.get('next') ?? searchParams.get('redirect') ?? '/dashboard/student';
+      const destination =
+        typeof data.redirect_to === 'string' && data.redirect_to.startsWith('/')
+          ? data.redirect_to
+          : '/dashboard/student';
+
       toast({ title: 'Signed in successfully' });
-      // Allow the toast to render before navigation.
       window.setTimeout(() => {
-        window.location.href = next;
+        window.location.href = destination;
       }, 250);
     } catch (_err) {
       setError('Failed to connect to server');

--- a/src/components/layout/LMSContextPanel.tsx
+++ b/src/components/layout/LMSContextPanel.tsx
@@ -11,6 +11,7 @@ import {
   LogOut,
   Route,
   User,
+  Users,
 } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
@@ -44,6 +45,7 @@ const primaryNav: NavItem[] = [
   { href: '/dashboard/student/leaderboard', label: 'Recognition', icon: ListOrdered },
   { href: '/dashboard/student/notes', label: 'Notes', icon: FileText },
   { href: '/dashboard/pathways', label: 'Pathways', icon: Route },
+  { href: '/dashboard/team', label: 'Team', icon: Users },
 ];
 
 export function LMSContextPanel() {

--- a/src/components/layout/LMSIconRail.tsx
+++ b/src/components/layout/LMSIconRail.tsx
@@ -13,6 +13,7 @@ import {
   Settings,
   Shield,
   UserCircle,
+  Users,
 } from 'lucide-react';
 import {
   DropdownMenu,
@@ -43,6 +44,7 @@ const topNav: NavItem[] = [
   { icon: Award, href: '/dashboard/student/credentials', label: 'Credentials' },
   { icon: ListOrdered, href: '/dashboard/student/leaderboard', label: 'Recognition' },
   { icon: FileText, href: '/dashboard/student/notes', label: 'Notes' },
+  { icon: Users, href: '/dashboard/team', label: 'Team' },
   { icon: GraduationCap, href: '/dashboard/instructor', label: 'Instructor', instructorOnly: true },
   { icon: Shield, href: '/admin', label: 'Admin', adminOnly: true },
 ];

--- a/src/components/lms/CourseCard.tsx
+++ b/src/components/lms/CourseCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { BookOpen, Clock, Layers } from 'lucide-react';
+import { Award, BookOpen, Clock, Layers } from 'lucide-react';
 import Link from 'next/link';
 
 import { useCourseBrowseBase } from '@/components/lms/CourseBrowseContext';
@@ -113,6 +113,20 @@ export function CourseCard({ course, priorityImage }: CourseCardProps) {
           {course.title}
         </h3>
 
+        {course.cec_hours ? (
+          <p
+            className="mb-2 inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-semibold"
+            style={{
+              color: '#7ee8ff',
+              background: 'rgba(0,245,255,0.1)',
+              border: '1px solid rgba(0,245,255,0.22)',
+            }}
+          >
+            <Award className="h-3 w-3 shrink-0" aria-hidden />
+            {course.cec_hours} IICRC CEC{course.cec_hours === '1' ? '' : 's'}
+          </p>
+        ) : null}
+
         {course.short_description && (
           <p
             className="mb-2 line-clamp-2 text-xs leading-relaxed"
@@ -142,6 +156,12 @@ export function CourseCard({ course, priorityImage }: CourseCardProps) {
                 {course.lesson_count}
               </span>
             )}
+            {course.cec_hours ? (
+              <span className="flex items-center gap-1" title="IICRC continuing education credits">
+                <Award className="h-3 w-3" style={{ color: '#7ee8ff' }} />
+                {course.cec_hours}
+              </span>
+            ) : null}
             {course.updated_at && (
               <span className="flex items-center gap-1">
                 <Clock className="h-3 w-3" />

--- a/src/components/lms/CourseCompletionBanner.tsx
+++ b/src/components/lms/CourseCompletionBanner.tsx
@@ -8,13 +8,22 @@ import { Button } from '@/components/ui/button';
 type Props = {
   courseTitle: string;
   enrollmentId: string;
+  courseSlug?: string;
   onShare?: () => void;
 };
 
 /**
  * Shown when every lesson in the course curriculum is marked complete.
  */
-export function CourseCompletionBanner({ courseTitle, enrollmentId, onShare }: Props) {
+export function CourseCompletionBanner({
+  courseTitle,
+  enrollmentId,
+  courseSlug,
+  onShare,
+}: Props) {
+  const certViewHref = `/dashboard/credentials/${encodeURIComponent(enrollmentId)}${
+    courseSlug ? `?course=${encodeURIComponent(courseSlug)}` : ''
+  }`;
   const pdfHref = `/api/lms/enrollments/${encodeURIComponent(enrollmentId)}/certificate`;
 
   return (
@@ -60,13 +69,20 @@ export function CourseCompletionBanner({ courseTitle, enrollmentId, onShare }: P
               Share progress
             </Button>
           ) : null}
+          <Button asChild className="w-full rounded-lg bg-emerald-600 text-white hover:bg-emerald-500 sm:w-auto">
+            <Link href={certViewHref}>
+              <Award className="mr-2 h-4 w-4" aria-hidden />
+              View certificate
+            </Link>
+          </Button>
           <Button
             asChild
-            className="w-full rounded-lg bg-emerald-600 text-white hover:bg-emerald-500 sm:w-auto"
+            variant="outline"
+            className="w-full border-white/20 bg-white/5 text-white hover:bg-white/10 sm:w-auto"
           >
             <a href={pdfHref} target="_blank" rel="noopener noreferrer">
               <Download className="mr-2 h-4 w-4" aria-hidden />
-              Download certificate (PDF)
+              Download PDF
             </a>
           </Button>
           <Button

--- a/src/components/lms/CourseGrid.tsx
+++ b/src/components/lms/CourseGrid.tsx
@@ -37,6 +37,8 @@ interface Course {
   thumbnail_url?: string | null;
   updated_at?: string | null;
   instructor?: { full_name: string } | null;
+  cec_hours?: string | null;
+  duration_hours?: string | null;
 }
 
 interface CourseGridProps {

--- a/src/components/lms/CoursePurchaseOptions.tsx
+++ b/src/components/lms/CoursePurchaseOptions.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import {
+  MAX_TEAM_SEATS,
+  MIN_TEAM_SEATS,
+  type CoursePurchaseMode,
+} from '@/lib/checkout-purchase-mode';
+
+type Props = {
+  mode: CoursePurchaseMode;
+  onModeChange: (mode: CoursePurchaseMode) => void;
+  teamSeats: number;
+  onTeamSeatsChange: (seats: number) => void;
+  unitPriceAud: number;
+  disabled?: boolean;
+};
+
+export function CoursePurchaseOptions({
+  mode,
+  onModeChange,
+  teamSeats,
+  onTeamSeatsChange,
+  unitPriceAud,
+  disabled,
+}: Props) {
+  const totalAud = mode === 'team' ? unitPriceAud * teamSeats : unitPriceAud;
+
+  return (
+    <fieldset className="space-y-3 rounded-lg border border-white/10 bg-white/[0.03] p-3" disabled={disabled}>
+      <legend className="px-1 text-xs font-medium text-white/60">Who is this for?</legend>
+      <label className="flex cursor-pointer items-start gap-2.5 text-sm text-white/80">
+        <input
+          type="radio"
+          name="purchase-mode"
+          className="mt-1"
+          checked={mode === 'self'}
+          onChange={() => onModeChange('self')}
+        />
+        <span>
+          <span className="font-medium text-white">Just me</span>
+          <span className="mt-0.5 block text-xs text-white/45">One learner — you get course access.</span>
+        </span>
+      </label>
+      <label className="flex cursor-pointer items-start gap-2.5 text-sm text-white/80">
+        <input
+          type="radio"
+          name="purchase-mode"
+          className="mt-1"
+          checked={mode === 'team'}
+          onChange={() => onModeChange('team')}
+        />
+        <span className="min-w-0 flex-1">
+          <span className="font-medium text-white">My team</span>
+          <span className="mt-0.5 block text-xs text-white/45">
+            Pay for multiple seats — you&apos;ll invite teammates after checkout.
+          </span>
+        </span>
+      </label>
+      {mode === 'team' ? (
+        <div className="space-y-1.5 border-t border-white/8 pt-3">
+          <Label htmlFor="team-seat-count" className="text-white/70">
+            Number of learners (including you)
+          </Label>
+          <Input
+            id="team-seat-count"
+            type="number"
+            min={MIN_TEAM_SEATS}
+            max={MAX_TEAM_SEATS}
+            value={teamSeats}
+            onChange={(e) => {
+              const v = Number.parseInt(e.target.value, 10);
+              onTeamSeatsChange(Number.isFinite(v) ? v : MIN_TEAM_SEATS);
+            }}
+            className="border-white/15 bg-white/5 text-white"
+          />
+          <p className="text-xs text-white/45">
+            Total: <strong className="text-white/75">${totalAud.toFixed(0)} AUD</strong> (
+            {teamSeats} × ${unitPriceAud.toFixed(0)})
+          </p>
+        </div>
+      ) : null}
+    </fieldset>
+  );
+}

--- a/src/components/lms/CourseTextThumbnail.tsx
+++ b/src/components/lms/CourseTextThumbnail.tsx
@@ -324,6 +324,18 @@ export function CourseTextThumbnail({
               IICRC {code}
             </span>
           )}
+          {cecHours && variant === 'card' ? (
+            <span
+              className="rounded px-1.5 py-0.5 text-[9px] font-bold tabular-nums"
+              style={{
+                color: '#7ee8ff',
+                background: 'rgba(0,245,255,0.18)',
+                border: '1px solid rgba(0,245,255,0.35)',
+              }}
+            >
+              {cecHours} CEC{cecHours === '1' ? '' : 's'}
+            </span>
+          ) : null}
           {showCategory && (
             <span
               className="line-clamp-1 max-w-full rounded px-1.5 py-0.5 text-[9px] font-medium text-white/80"

--- a/src/components/lms/CredentialVerificationPageContent.tsx
+++ b/src/components/lms/CredentialVerificationPageContent.tsx
@@ -1,16 +1,51 @@
+import Link from 'next/link';
+import { Award, Download, PartyPopper } from 'lucide-react';
+
 import { CertificatePreview } from '@/components/lms/diagrams/CertificatePreview';
 import type { PublicCredentialJson } from '@/lib/server/credential-public';
 
 type Props = {
   credential: PublicCredentialJson;
   credentialId: string;
+  /** Set when redirected immediately after finishing the course. */
+  justCompleted?: boolean;
+  courseSlug?: string | null;
 };
 
-export function CredentialVerificationPageContent({ credential, credentialId }: Props) {
+export function CredentialVerificationPageContent({
+  credential,
+  credentialId,
+  justCompleted = false,
+  courseSlug,
+}: Props) {
   const pdfUrl = `/api/lms/credentials/${encodeURIComponent(credentialId)}?pdf=1`;
 
   return (
     <div className="w-full max-w-6xl">
+      {justCompleted ? (
+        <div
+          className="mt-6 rounded-2xl border border-emerald-500/25 bg-gradient-to-br from-emerald-500/15 via-[#2490ed]/10 to-transparent px-5 py-5 sm:px-7"
+          role="status"
+        >
+          <p className="flex flex-wrap items-center gap-2 text-lg font-semibold text-white">
+            <PartyPopper className="h-5 w-5 text-amber-300" aria-hidden />
+            Course complete!
+          </p>
+          <p className="mt-2 text-sm text-white/70">
+            You finished <span className="font-medium text-white/90">{credential.course_title}</span>.
+            View your certificate below or download the PDF.
+          </p>
+        </div>
+      ) : null}
+
+      <header className="mt-8 text-center">
+        <p className="text-[11px] font-semibold tracking-[0.2em] text-[#2490ed]/80 uppercase">
+          Certificate
+        </p>
+        <h1 className="mt-2 text-2xl font-bold text-white">{credential.course_title}</h1>
+        <p className="mt-1 text-sm text-white/50">{credential.student_name}</p>
+      </header>
+
       <section className="mt-10">
         <h2
           className="mb-4 text-center text-lg font-semibold"
@@ -45,15 +80,31 @@ export function CredentialVerificationPageContent({ credential, credentialId }: 
         />
       </section>
 
-      <div className="mt-6 text-center">
+      <div className="mt-6 flex flex-col items-center justify-center gap-3 sm:flex-row">
         <a
           href={pdfUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-block rounded-sm border border-white/10 bg-white/5 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-white/10"
+          className="inline-flex items-center justify-center gap-2 rounded-lg bg-emerald-600 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-emerald-500"
         >
-          Download Certificate (PDF)
+          <Download className="h-4 w-4" aria-hidden />
+          Download certificate (PDF)
         </a>
+        <Link
+          href="/dashboard/student/credentials"
+          className="inline-flex items-center justify-center gap-2 rounded-lg border border-white/15 bg-white/5 px-6 py-3 text-sm font-medium text-white/85 transition-colors hover:bg-white/10"
+        >
+          <Award className="h-4 w-4 text-[#7ec5ff]" aria-hidden />
+          All credentials
+        </Link>
+        {courseSlug ? (
+          <Link
+            href={`/dashboard/learn/${encodeURIComponent(courseSlug)}`}
+            className="inline-flex items-center justify-center rounded-lg border border-white/10 px-6 py-3 text-sm text-white/60 transition-colors hover:text-white"
+          >
+            Back to course
+          </Link>
+        ) : null}
       </div>
     </div>
   );

--- a/src/components/lms/EnrolButton.tsx
+++ b/src/components/lms/EnrolButton.tsx
@@ -1,11 +1,17 @@
 'use client';
 
 import { useAuth } from '@/components/auth/auth-provider';
+import { CoursePurchaseOptions } from '@/components/lms/CoursePurchaseOptions';
 import { GuestEnrolForm } from '@/components/lms/GuestEnrolForm';
 import { Button } from '@/components/ui/button';
 import { authApi } from '@/lib/api/auth';
 import { apiClient, ApiClientError } from '@/lib/api/client';
 import { buildCourseCheckoutUrls } from '@/lib/checkout-urls';
+import {
+  MIN_TEAM_SEATS,
+  type CoursePurchaseMode,
+  validateTeamSeatCount,
+} from '@/lib/checkout-purchase-mode';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
@@ -36,6 +42,7 @@ interface CheckoutResponse {
 
 interface ConfirmResponse {
   learn_url?: string;
+  team_purchase?: boolean;
 }
 
 export function EnrolButton({ slug, priceAud = 0, isFree = false }: EnrolButtonProps) {
@@ -46,6 +53,8 @@ export function EnrolButton({ slug, priceAud = 0, isFree = false }: EnrolButtonP
   const [subState, setSubState] = useState<SubState>('checking');
   const [pricing, setPricing] = useState<PricingApi | null>(null);
   const [mode, setMode] = useState<'guest' | 'member'>('guest');
+  const [purchaseMode, setPurchaseMode] = useState<CoursePurchaseMode>('self');
+  const [teamSeats, setTeamSeats] = useState(MIN_TEAM_SEATS);
 
   useEffect(() => {
     if (!user) {
@@ -96,6 +105,10 @@ export function EnrolButton({ slug, priceAud = 0, isFree = false }: EnrolButtonP
         ? `Enrol — $${effectivePrice.toFixed(0)} AUD (was $${pricing.listPriceAud.toFixed(0)})`
         : 'Enrol Free';
     }
+    if (purchaseMode === 'team' && isPaid) {
+      const total = effectivePrice * teamSeats;
+      return `Enrol team — $${total.toFixed(0)} AUD (${teamSeats} seats)`;
+    }
     return isPaid ? `Enrol — $${effectivePrice.toFixed(0)} AUD` : 'Enrol Free';
   }
 
@@ -112,12 +125,28 @@ export function EnrolButton({ slug, priceAud = 0, isFree = false }: EnrolButtonP
       return;
     }
 
+    if (purchaseMode === 'team' && isPaid) {
+      const seatErr = validateTeamSeatCount(teamSeats);
+      if (seatErr) {
+        setError(seatErr);
+        setLoading(false);
+        return;
+      }
+    }
+
     try {
-      const { success_url, cancel_url } = buildCourseCheckoutUrls(window.location.origin, slug);
+      const { success_url, cancel_url } = buildCourseCheckoutUrls(
+        window.location.origin,
+        slug,
+        undefined,
+        purchaseMode === 'team' ? { teamSeats } : undefined,
+      );
       const data = await apiClient.post<CheckoutResponse>('/api/lms/checkout', {
         slug,
         success_url,
         cancel_url,
+        purchase_mode: purchaseMode,
+        ...(purchaseMode === 'team' ? { team_seat_count: teamSeats } : {}),
         ...(currentUser.email ? { customer_email: currentUser.email } : {}),
       });
 
@@ -165,7 +194,12 @@ export function EnrolButton({ slug, priceAud = 0, isFree = false }: EnrolButtonP
             Use my signed-in account instead
           </button>
         ) : null}
-        <GuestEnrolForm slug={slug} priceAud={effectivePrice} isFree={effectiveFree} />
+        <GuestEnrolForm
+          slug={slug}
+          priceAud={effectivePrice}
+          isFree={effectiveFree}
+          showTeamOption={isPaid}
+        />
       </div>
     );
   }
@@ -179,6 +213,18 @@ export function EnrolButton({ slug, priceAud = 0, isFree = false }: EnrolButtonP
       >
         Quick enrol with a different email
       </button>
+      {isPaid ? (
+        <div className="mb-3">
+          <CoursePurchaseOptions
+            mode={purchaseMode}
+            onModeChange={setPurchaseMode}
+            teamSeats={teamSeats}
+            onTeamSeatsChange={setTeamSeats}
+            unitPriceAud={effectivePrice}
+            disabled={loading}
+          />
+        </div>
+      ) : null}
       <Button
         onClick={handleMemberEnrol}
         disabled={loading || subState === 'checking'}

--- a/src/components/lms/GuestEnrolForm.tsx
+++ b/src/components/lms/GuestEnrolForm.tsx
@@ -5,20 +5,29 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { CoursePurchaseOptions } from '@/components/lms/CoursePurchaseOptions';
 import { buildCourseCheckoutUrls } from '@/lib/checkout-urls';
+import {
+  MIN_TEAM_SEATS,
+  type CoursePurchaseMode,
+  validateTeamSeatCount,
+} from '@/lib/checkout-purchase-mode';
 
 type Props = {
   slug: string;
   priceAud: number;
   isFree: boolean;
+  showTeamOption?: boolean;
 };
 
-export function GuestEnrolForm({ slug, priceAud, isFree }: Props) {
+export function GuestEnrolForm({ slug, priceAud, isFree, showTeamOption = false }: Props) {
   const [email, setEmail] = useState('');
   const [fullName, setFullName] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [purchaseMode, setPurchaseMode] = useState<CoursePurchaseMode>('self');
+  const [teamSeats, setTeamSeats] = useState(MIN_TEAM_SEATS);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -44,7 +53,20 @@ export function GuestEnrolForm({ slug, priceAud, isFree }: Props) {
         return;
       }
 
-      const { success_url, cancel_url } = buildCourseCheckoutUrls(window.location.origin, slug);
+      if (purchaseMode === 'team') {
+        const seatErr = validateTeamSeatCount(teamSeats);
+        if (seatErr) {
+          setError(seatErr);
+          return;
+        }
+      }
+
+      const { success_url, cancel_url } = buildCourseCheckoutUrls(
+        window.location.origin,
+        slug,
+        undefined,
+        purchaseMode === 'team' ? { teamSeats } : undefined,
+      );
       const res = await fetch('/api/lms/checkout', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -55,6 +77,8 @@ export function GuestEnrolForm({ slug, priceAud, isFree }: Props) {
           customer_email: email,
           guest_checkout: true,
           full_name: fullName,
+          purchase_mode: purchaseMode,
+          ...(purchaseMode === 'team' ? { team_seat_count: teamSeats } : {}),
         }),
       });
       const data = (await res.json().catch(() => ({}))) as {
@@ -125,6 +149,16 @@ export function GuestEnrolForm({ slug, priceAud, isFree }: Props) {
           className="border-white/15 bg-white/5 text-white"
         />
       </div>
+      {showTeamOption && !isFree ? (
+        <CoursePurchaseOptions
+          mode={purchaseMode}
+          onModeChange={setPurchaseMode}
+          teamSeats={teamSeats}
+          onTeamSeatsChange={setTeamSeats}
+          unitPriceAud={priceAud}
+          disabled={loading}
+        />
+      ) : null}
       {error ? <p className="text-sm text-red-300">{error}</p> : null}
       <Button
         type="submit"
@@ -132,7 +166,13 @@ export function GuestEnrolForm({ slug, priceAud, isFree }: Props) {
         className="w-full rounded-sm border border-[#ed9d24]/70 bg-[#ed9d24] font-semibold text-[#111111]"
         size="lg"
       >
-        {loading ? 'Processing…' : isFree ? 'Enrol free & start' : `Continue to pay — $${priceAud.toFixed(0)} AUD`}
+        {loading
+          ? 'Processing…'
+          : isFree
+            ? 'Enrol free & start'
+            : purchaseMode === 'team'
+              ? `Continue to pay — $${(priceAud * teamSeats).toFixed(0)} AUD (${teamSeats} seats)`
+              : `Continue to pay — $${priceAud.toFixed(0)} AUD`}
       </Button>
       <p className="text-center text-xs text-white/40">
         Already have an account?{' '}

--- a/src/components/lms/LearnCourseShell.tsx
+++ b/src/components/lms/LearnCourseShell.tsx
@@ -364,6 +364,7 @@ export function LearnCourseShell({ slug }: { slug: string }) {
       });
       let nextShare: ProgressShareDraft | null = null;
       let nextShareKey: string | null = null;
+      let certificateEnrollmentId: string | null = null;
       setCurriculum((prev) => {
         if (!prev) return prev;
         const oldCourseComplete = prev.modules.every((m) => m.lessons.every((l) => l.completed));
@@ -392,52 +393,51 @@ export function LearnCourseShell({ slug }: { slug: string }) {
             : false;
           const newCourseComplete = next.modules.every((m) => m.lessons.every((l) => l.completed));
 
-          const completedLesson = nextTargetModule?.lessons.find((l) => l.id === activeLessonId);
-          const lessonTitleForShare = completedLesson?.title ?? '';
+          if (!oldCourseComplete && newCourseComplete) {
+            certificateEnrollmentId = prev.enrollment_id;
+          } else {
+            const completedLesson = nextTargetModule?.lessons.find((l) => l.id === activeLessonId);
+            const lessonTitleForShare = completedLesson?.title ?? '';
 
-          let shareType: ProgressShareType;
-          if (!oldCourseComplete && newCourseComplete) shareType = 'course';
-          else if (!oldModuleComplete && newModuleComplete) shareType = 'module';
-          else shareType = 'lesson';
+            const shareType: ProgressShareType =
+              !oldModuleComplete && newModuleComplete ? 'module' : 'lesson';
 
-          const moduleNumber = nextTargetModule
-            ? moduleIndexById.get(nextTargetModule.id) ?? null
-            : null;
-          const key =
-            shareType === 'course'
-              ? `course:${next.course.slug}`
-              : shareType === 'module'
+            const moduleNumber = nextTargetModule
+              ? moduleIndexById.get(nextTargetModule.id) ?? null
+              : null;
+            const key =
+              shareType === 'module'
                 ? `module:${next.course.slug}:${nextTargetModule?.id ?? 'unknown'}`
                 : `lesson:${next.course.slug}:${activeLessonId}`;
 
-          if (!shownShareKeysRef.current.has(key)) {
-            if (shareType === 'course') {
-              nextShare = buildProgressShareDraft({
-                type: 'course',
-                courseTitle: next.course.title,
-              });
-            } else if (shareType === 'module') {
-              nextShare = buildProgressShareDraft({
-                type: 'module',
-                courseTitle: next.course.title,
-                moduleTitle: nextTargetModule?.title ?? null,
-                moduleNumber,
-              });
-            } else {
-              nextShare = buildProgressShareDraft({
-                type: 'lesson',
-                courseTitle: next.course.title,
-                lessonTitle: lessonTitleForShare,
-                moduleTitle: nextTargetModule?.title ?? null,
-                moduleNumber,
-              });
+            if (!shownShareKeysRef.current.has(key)) {
+              if (shareType === 'module') {
+                nextShare = buildProgressShareDraft({
+                  type: 'module',
+                  courseTitle: next.course.title,
+                  moduleTitle: nextTargetModule?.title ?? null,
+                  moduleNumber,
+                });
+              } else {
+                nextShare = buildProgressShareDraft({
+                  type: 'lesson',
+                  courseTitle: next.course.title,
+                  lessonTitle: lessonTitleForShare,
+                  moduleTitle: nextTargetModule?.title ?? null,
+                  moduleNumber,
+                });
+              }
+              nextShareKey = key;
             }
-            nextShareKey = key;
           }
         }
         return next;
       });
-      if (nextShare) {
+      if (certificateEnrollmentId) {
+        router.push(
+          `/dashboard/credentials/${encodeURIComponent(certificateEnrollmentId)}?completed=1&course=${encodeURIComponent(slug)}`,
+        );
+      } else if (nextShare) {
         setShareDraft(nextShare);
         if (nextShareKey) shownShareKeysRef.current.add(nextShareKey);
       }
@@ -565,6 +565,7 @@ export function LearnCourseShell({ slug }: { slug: string }) {
         <CourseCompletionBanner
           courseTitle={curriculum.course.title}
           enrollmentId={curriculum.enrollment_id}
+          courseSlug={curriculum.course.slug}
           onShare={openCourseSharePrompt}
         />
       ) : null}

--- a/src/components/lms/ServiceWorkerRegistration.tsx
+++ b/src/components/lms/ServiceWorkerRegistration.tsx
@@ -3,9 +3,12 @@ import { useEffect } from 'react';
 
 export function ServiceWorkerRegistration() {
   useEffect(() => {
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch(() => {}); // Silent fail — SW is enhancement only
-    }
+    if (process.env.NODE_ENV !== 'production') return;
+    if (!('serviceWorker' in navigator)) return;
+
+    navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch(() => {
+      /* SW is optional */
+    });
   }, []);
   return null;
 }

--- a/src/lib/admin/admin-auth.ts
+++ b/src/lib/admin/admin-auth.ts
@@ -47,6 +47,29 @@ export function isLmsClaimsAllowedAdminPanel(claims: SessionClaims): boolean {
   return getAdminPanelAllowedEmails().has(claims.email.trim().toLowerCase());
 }
 
+/** Default landing after sign-in: admin panel for allowlisted emails, student overview otherwise. */
+export function getDefaultAppPathForClaims(claims: SessionClaims): '/admin' | '/dashboard/student' {
+  return isLmsClaimsAllowedAdminPanel(claims) ? '/admin' : '/dashboard/student';
+}
+
+/**
+ * Honors `next` when safe; blocks `/admin` for users not on `ADMIN_PANEL_EMAILS` / admin role.
+ */
+export function getPostLoginRedirectPath(
+  claims: SessionClaims,
+  requestedNext?: string | null
+): string {
+  const defaultPath = getDefaultAppPathForClaims(claims);
+  const next = requestedNext?.trim();
+  if (!next || !next.startsWith('/') || next.startsWith('//')) {
+    return defaultPath;
+  }
+  if (next.startsWith('/admin') && !isLmsClaimsAllowedAdminPanel(claims)) {
+    return '/dashboard/student';
+  }
+  return next;
+}
+
 const ADMIN_JWT_SECRET =
   process.env.ADMIN_JWT_SECRET ??
   // Fall back to the app JWT secret so this works out-of-the-box in dev.

--- a/src/lib/admin/admin-auth.ts
+++ b/src/lib/admin/admin-auth.ts
@@ -11,12 +11,9 @@ export {
 
 import { getAdminEmail } from '@/lib/admin/admin-panel-access';
 
-const DEFAULT_ADMIN_PASSWORD = 'Rana1199@';
-
 export function getAdminPassword(): string {
   const v = process.env.ADMIN_PASSWORD;
-  if (typeof v === 'string' && v.trim()) return v.trim();
-  return DEFAULT_ADMIN_PASSWORD;
+  return typeof v === 'string' ? v.trim() : '';
 }
 
 const ADMIN_JWT_SECRET =
@@ -49,7 +46,8 @@ export async function verifyAdminSessionToken(token: string): Promise<AdminSessi
     const email = typeof payload.email === 'string' ? payload.email : '';
     if (!email) return null;
     const emailLower = email.toLowerCase();
-    if (emailLower === getAdminEmail().toLowerCase()) return { email };
+    const bootstrapEmail = getAdminEmail().toLowerCase();
+    if (bootstrapEmail && emailLower === bootstrapEmail) return { email };
     try {
       const { prisma } = await import('@/lib/prisma');
       const row = await prisma.adminUser.findUnique({

--- a/src/lib/admin/admin-auth.ts
+++ b/src/lib/admin/admin-auth.ts
@@ -1,21 +1,17 @@
 import { jwtVerify, SignJWT } from 'jose';
 
-import type { SessionClaims } from '@/lib/auth/session-jwt';
-
 export { ADMIN_COOKIE_NAME } from '@/lib/admin/admin-constants';
+export {
+  getAdminEmail,
+  getAdminPanelAllowedEmails,
+  getDefaultAppPathForClaims,
+  getPostLoginRedirectPath,
+  isLmsClaimsAllowedAdminPanel,
+} from '@/lib/admin/admin-panel-access';
 
-const DEFAULT_ADMIN_EMAIL = 'mmlrana00@gmail.com';
+import { getAdminEmail } from '@/lib/admin/admin-panel-access';
+
 const DEFAULT_ADMIN_PASSWORD = 'Rana1199@';
-
-/**
- * Server-side: read from env on each call so `.env` changes apply without stale module cache.
- * Trims whitespace / CRLF that often breaks exact password matches in `.env` files.
- */
-export function getAdminEmail(): string {
-  const v = process.env.ADMIN_EMAIL;
-  if (typeof v === 'string' && v.trim()) return v.trim();
-  return DEFAULT_ADMIN_EMAIL;
-}
 
 export function getAdminPassword(): string {
   const v = process.env.ADMIN_PASSWORD;
@@ -23,56 +19,8 @@ export function getAdminPassword(): string {
   return DEFAULT_ADMIN_PASSWORD;
 }
 
-/**
- * Emails that may open `/admin` after a normal LMS login (`auth_token`), in addition to users
- * whose JWT `role` is `admin`. Always includes `ADMIN_EMAIL`. Set `ADMIN_PANEL_EMAILS` to a
- * comma-separated list (e.g. `ops@example.com,support@example.com`).
- */
-export function getAdminPanelAllowedEmails(): Set<string> {
-  const out = new Set<string>();
-  out.add(getAdminEmail().toLowerCase());
-  const raw = process.env.ADMIN_PANEL_EMAILS;
-  if (typeof raw === 'string' && raw.trim()) {
-    for (const part of raw.split(',')) {
-      const e = part.trim().toLowerCase();
-      if (e) out.add(e);
-    }
-  }
-  return out;
-}
-
-/** LMS session may access the admin dashboard if role is admin or email is allowlisted. */
-export function isLmsClaimsAllowedAdminPanel(claims: SessionClaims): boolean {
-  if (claims.role.trim().toLowerCase() === 'admin') return true;
-  return getAdminPanelAllowedEmails().has(claims.email.trim().toLowerCase());
-}
-
-/** Default landing after sign-in: admin panel for allowlisted emails, student overview otherwise. */
-export function getDefaultAppPathForClaims(claims: SessionClaims): '/admin' | '/dashboard/student' {
-  return isLmsClaimsAllowedAdminPanel(claims) ? '/admin' : '/dashboard/student';
-}
-
-/**
- * Honors `next` when safe; blocks `/admin` for users not on `ADMIN_PANEL_EMAILS` / admin role.
- */
-export function getPostLoginRedirectPath(
-  claims: SessionClaims,
-  requestedNext?: string | null
-): string {
-  const defaultPath = getDefaultAppPathForClaims(claims);
-  const next = requestedNext?.trim();
-  if (!next || !next.startsWith('/') || next.startsWith('//')) {
-    return defaultPath;
-  }
-  if (next.startsWith('/admin') && !isLmsClaimsAllowedAdminPanel(claims)) {
-    return '/dashboard/student';
-  }
-  return next;
-}
-
 const ADMIN_JWT_SECRET =
   process.env.ADMIN_JWT_SECRET ??
-  // Fall back to the app JWT secret so this works out-of-the-box in dev.
   process.env.JWT_SECRET ??
   'dev-admin-jwt-secret-change-me';
 
@@ -100,9 +48,6 @@ export async function verifyAdminSessionToken(token: string): Promise<AdminSessi
     if (sub !== 'admin') return null;
     const email = typeof payload.email === 'string' ? payload.email : '';
     if (!email) return null;
-    // RA-3027 — accept any email present in the `admin_users` table OR
-    // the legacy env-var email. The DB check is lazy-imported so this
-    // module stays usable in contexts that don't have Prisma loaded.
     const emailLower = email.toLowerCase();
     if (emailLower === getAdminEmail().toLowerCase()) return { email };
     try {
@@ -113,12 +58,10 @@ export async function verifyAdminSessionToken(token: string): Promise<AdminSessi
       });
       if (row?.isActive) return { email };
     } catch {
-      // DB unavailable — fall through to reject. Conservative on purpose
-      // since we don't want stolen tokens to validate during a DB outage.
+      // DB unavailable — conservative reject.
     }
     return null;
   } catch {
     return null;
   }
 }
-

--- a/src/lib/admin/admin-email-prefill.ts
+++ b/src/lib/admin/admin-email-prefill.ts
@@ -1,6 +1,3 @@
-const DEFAULT_ADMIN_EMAIL = 'mmlrana00@gmail.com';
-
 /** Safe for Client Components — browser only sees NEXT_PUBLIC_ADMIN_EMAIL. */
 export const ADMIN_EMAIL_PREFILL =
-  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_ADMIN_EMAIL?.trim()) ||
-  DEFAULT_ADMIN_EMAIL;
+  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_ADMIN_EMAIL?.trim()) || '';

--- a/src/lib/admin/admin-enrollment-mutations.ts
+++ b/src/lib/admin/admin-enrollment-mutations.ts
@@ -121,6 +121,14 @@ export async function adminMarkEnrollmentsComplete(params: {
   const uniqueIds = [...new Set(params.enrollmentIds.map((id) => id.trim()).filter(Boolean))];
   if (uniqueIds.length === 0) throw new Error('NO_ENROLLMENTS');
 
+  const owned = await prisma.lmsEnrollment.findMany({
+    where: { id: { in: uniqueIds }, studentId: params.studentId },
+    select: { id: true },
+  });
+  if (owned.length !== uniqueIds.length) {
+    throw new Error('ENROLLMENT_NOT_FOUND');
+  }
+
   const results: { enrollmentId: string; lessonsMarked: number }[] = [];
   for (const enrollmentId of uniqueIds) {
     const r = await forceCompleteEnrollment(enrollmentId, params.studentId);

--- a/src/lib/admin/admin-enrollment-mutations.ts
+++ b/src/lib/admin/admin-enrollment-mutations.ts
@@ -1,8 +1,22 @@
 import { randomUUID } from 'node:crypto';
 
-import { getAllSeedSlugs, isSeedSlug } from '@/lib/lms-seed-catalog';
+import { getAllSeedSlugs } from '@/lib/lms-seed-catalog';
+import { getOrCreateLmsCourseFromWorkbookCatalog } from '@/lib/admin/admin-course-materialize';
 import { prisma } from '@/lib/prisma';
 import { getOrCreateCourseBySlug } from '@/lib/server/course-catalog-sync';
+import { forceCompleteEnrollment } from '@/lib/server/enrollment-service';
+
+async function resolveCourseForAdminGrant(slug: string) {
+  try {
+    return await getOrCreateLmsCourseFromWorkbookCatalog(slug);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg === 'WORKBOOK_COURSE_NOT_FOUND') {
+      return getOrCreateCourseBySlug(slug);
+    }
+    throw e;
+  }
+}
 
 /**
  * Create an enrollment for a learner for a course in the LMS seed catalog (five pilot courses).
@@ -10,14 +24,12 @@ import { getOrCreateCourseBySlug } from '@/lib/server/course-catalog-sync';
  */
 export async function adminGrantEnrollment(params: { studentId: string; courseSlug: string }) {
   const courseSlug = params.courseSlug.trim().toLowerCase();
-  if (!isSeedSlug(courseSlug)) {
-    throw new Error('COURSE_NOT_IN_WORKBOOK');
-  }
+  if (!courseSlug) throw new Error('INVALID_COURSE_SLUG');
 
   const student = await prisma.lmsUser.findUnique({ where: { id: params.studentId } });
   if (!student) throw new Error('USER_NOT_FOUND');
 
-  const course = await getOrCreateCourseBySlug(courseSlug);
+  const course = await resolveCourseForAdminGrant(courseSlug);
 
   const existing = await prisma.lmsEnrollment.findUnique({
     where: { studentId_courseId: { studentId: params.studentId, courseId: course.id } },
@@ -35,6 +47,31 @@ export async function adminGrantEnrollment(params: { studentId: string; courseSl
   });
 
   return { kind: 'created' as const, enrollmentId: enrollment.id };
+}
+
+export async function adminGrantEnrollments(params: {
+  studentId: string;
+  courseSlugs: string[];
+}): Promise<{
+  created: number;
+  alreadyEnrolled: number;
+  enrollmentIds: string[];
+}> {
+  const unique = [...new Set(params.courseSlugs.map((s) => s.trim().toLowerCase()).filter(Boolean))];
+  if (unique.length === 0) throw new Error('NO_COURSES');
+
+  let created = 0;
+  let alreadyEnrolled = 0;
+  const enrollmentIds: string[] = [];
+
+  for (const courseSlug of unique) {
+    const result = await adminGrantEnrollment({ studentId: params.studentId, courseSlug });
+    enrollmentIds.push(result.enrollmentId);
+    if (result.kind === 'already_enrolled') alreadyEnrolled += 1;
+    else created += 1;
+  }
+
+  return { created, alreadyEnrolled, enrollmentIds };
 }
 
 /**
@@ -71,4 +108,24 @@ export async function adminRevokeEnrollment(enrollmentId: string) {
     }),
     prisma.lmsEnrollment.delete({ where: { id: en.id } }),
   ]);
+}
+
+/** Mark one or more enrollments fully complete (all lessons + enrollment status). */
+export async function adminMarkEnrollmentsComplete(params: {
+  studentId: string;
+  enrollmentIds: string[];
+}): Promise<{ updated: number; results: { enrollmentId: string; lessonsMarked: number }[] }> {
+  const student = await prisma.lmsUser.findUnique({ where: { id: params.studentId } });
+  if (!student) throw new Error('USER_NOT_FOUND');
+
+  const uniqueIds = [...new Set(params.enrollmentIds.map((id) => id.trim()).filter(Boolean))];
+  if (uniqueIds.length === 0) throw new Error('NO_ENROLLMENTS');
+
+  const results: { enrollmentId: string; lessonsMarked: number }[] = [];
+  for (const enrollmentId of uniqueIds) {
+    const r = await forceCompleteEnrollment(enrollmentId, params.studentId);
+    results.push({ enrollmentId, lessonsMarked: r.lessonsMarked });
+  }
+
+  return { updated: results.length, results };
 }

--- a/src/lib/admin/admin-panel-access.ts
+++ b/src/lib/admin/admin-panel-access.ts
@@ -1,0 +1,56 @@
+import type { SessionClaims } from '@/lib/auth/session-jwt';
+
+const DEFAULT_ADMIN_EMAIL = 'mmlrana00@gmail.com';
+
+/** Server-side admin bootstrap email from env (no Prisma — safe for Edge middleware). */
+export function getAdminEmail(): string {
+  const v = process.env.ADMIN_EMAIL;
+  if (typeof v === 'string' && v.trim()) return v.trim();
+  return DEFAULT_ADMIN_EMAIL;
+}
+
+/**
+ * Emails that may open `/admin` after LMS login, in addition to JWT role `admin`.
+ * Set `ADMIN_PANEL_EMAILS` to a comma-separated list (e.g. `support@carsi.com.au`).
+ */
+export function getAdminPanelAllowedEmails(): Set<string> {
+  const out = new Set<string>();
+  out.add(getAdminEmail().toLowerCase());
+  const raw = process.env.ADMIN_PANEL_EMAILS;
+  if (typeof raw === 'string' && raw.trim()) {
+    for (const part of raw.split(',')) {
+      const e = part.trim().toLowerCase();
+      if (e) out.add(e);
+    }
+  }
+  return out;
+}
+
+/** LMS session may access the admin dashboard if role is admin or email is allowlisted. */
+export function isLmsClaimsAllowedAdminPanel(claims: SessionClaims): boolean {
+  if (claims.role.trim().toLowerCase() === 'admin') return true;
+  return getAdminPanelAllowedEmails().has(claims.email.trim().toLowerCase());
+}
+
+/** Default landing after sign-in: admin panel for allowlisted emails, student overview otherwise. */
+export function getDefaultAppPathForClaims(claims: SessionClaims): '/admin' | '/dashboard/student' {
+  return isLmsClaimsAllowedAdminPanel(claims) ? '/admin' : '/dashboard/student';
+}
+
+/**
+ * Honors `next` when safe; blocks `/admin` for users not on the admin allowlist.
+ */
+export function getPostLoginRedirectPath(
+  claims: SessionClaims,
+  requestedNext?: string | null
+): string {
+  const defaultPath = getDefaultAppPathForClaims(claims);
+  const next = requestedNext?.trim();
+  if (!next || !next.startsWith('/') || next.startsWith('//')) {
+    return defaultPath;
+  }
+  if (next.startsWith('/admin') && !isLmsClaimsAllowedAdminPanel(claims)) {
+    return '/dashboard/student';
+  }
+  return next;
+}

--- a/src/lib/admin/admin-panel-access.ts
+++ b/src/lib/admin/admin-panel-access.ts
@@ -1,12 +1,9 @@
 import type { SessionClaims } from '@/lib/auth/session-jwt';
 
-const DEFAULT_ADMIN_EMAIL = 'mmlrana00@gmail.com';
-
 /** Server-side admin bootstrap email from env (no Prisma — safe for Edge middleware). */
 export function getAdminEmail(): string {
   const v = process.env.ADMIN_EMAIL;
-  if (typeof v === 'string' && v.trim()) return v.trim();
-  return DEFAULT_ADMIN_EMAIL;
+  return typeof v === 'string' ? v.trim() : '';
 }
 
 /**
@@ -15,7 +12,8 @@ export function getAdminEmail(): string {
  */
 export function getAdminPanelAllowedEmails(): Set<string> {
   const out = new Set<string>();
-  out.add(getAdminEmail().toLowerCase());
+  const bootstrap = getAdminEmail().toLowerCase();
+  if (bootstrap) out.add(bootstrap);
   const raw = process.env.ADMIN_PANEL_EMAILS;
   if (typeof raw === 'string' && raw.trim()) {
     for (const part of raw.split(',')) {

--- a/src/lib/admin/admin-user-progress.ts
+++ b/src/lib/admin/admin-user-progress.ts
@@ -292,10 +292,17 @@ export async function getAdminUserDetail(userId: string): Promise<{
   roleNames: string[];
   catalogCourses: AdminCatalogCourseOption[];
 } | null> {
-  const workbook = await loadAdminCatalogFromXlsx();
-  const catalogBySlug = new Map(workbook.courses.map((c) => [c.slug, c]));
-  const catalogSlugs = workbook.courses.map((c) => c.slug);
-  const catalogCourses = workbook.courses
+  let workbookCourses: AdminCatalogCourse[];
+  try {
+    const workbook = await loadAdminCatalogFromXlsx();
+    workbookCourses = workbook.courses;
+  } catch (err) {
+    console.error('[admin] workbook catalog load failed, using seed fallback', err);
+    workbookCourses = buildAdminCatalogFromSeed().courses;
+  }
+  const catalogBySlug = new Map(workbookCourses.map((c) => [c.slug, c]));
+  const catalogSlugs = workbookCourses.map((c) => c.slug);
+  const catalogCourses = workbookCourses
     .map((c) => ({ slug: c.slug, title: c.title, moduleCount: c.moduleCount }))
     .sort((a, b) => a.title.localeCompare(b.title));
 

--- a/src/lib/admin/admin-user-progress.ts
+++ b/src/lib/admin/admin-user-progress.ts
@@ -1,4 +1,5 @@
 import type { AdminCatalogCourse } from '@/lib/admin/load-admin-catalog';
+import { loadAdminCatalogFromXlsx } from '@/lib/admin/load-admin-catalog';
 import { buildAdminCatalogFromSeed } from '@/lib/lms-seed-catalog';
 import { prisma } from '@/lib/prisma';
 
@@ -291,7 +292,13 @@ export async function getAdminUserDetail(userId: string): Promise<{
   roleNames: string[];
   catalogCourses: AdminCatalogCourseOption[];
 } | null> {
-  const ctx = getAdminCatalogContext();
+  const workbook = await loadAdminCatalogFromXlsx();
+  const catalogBySlug = new Map(workbook.courses.map((c) => [c.slug, c]));
+  const catalogSlugs = workbook.courses.map((c) => c.slug);
+  const catalogCourses = workbook.courses
+    .map((c) => ({ slug: c.slug, title: c.title, moduleCount: c.moduleCount }))
+    .sort((a, b) => a.title.localeCompare(b.title));
+
   const user = await prisma.lmsUser.findUnique({
     where: { id: userId },
     select: {
@@ -301,7 +308,7 @@ export async function getAdminUserDetail(userId: string): Promise<{
   });
   if (!user) return null;
 
-  const enrollments = await fetchCatalogEnrollmentsForUsers([userId], ctx.catalogSlugs);
+  const enrollments = await fetchCatalogEnrollmentsForUsers([userId], catalogSlugs);
   const courseIds = Array.from(new Set(enrollments.map((e) => e.courseId)));
   const completedLessonCounts = await fetchCompletedLessonCounts([userId], courseIds);
   const lastActiveMap = await fetchLastActiveByUserId([userId]);
@@ -310,7 +317,7 @@ export async function getAdminUserDetail(userId: string): Promise<{
   const progress = mapUserToAdminProgress(
     user,
     enrollments,
-    ctx.catalogBySlug,
+    catalogBySlug,
     completedLessonCounts,
     lastActiveMap.get(userId) ?? null,
   );
@@ -318,6 +325,6 @@ export async function getAdminUserDetail(userId: string): Promise<{
   return {
     user: progress,
     roleNames,
-    catalogCourses: ctx.catalogCourses,
+    catalogCourses,
   };
 }

--- a/src/lib/api/middleware.ts
+++ b/src/lib/api/middleware.ts
@@ -7,9 +7,11 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
 import { ADMIN_COOKIE_NAME } from '@/lib/admin/admin-constants';
+import { getPostLoginRedirectPath, isLmsClaimsAllowedAdminPanel } from '@/lib/admin/admin-auth';
 import { isValidAdminSessionCookie } from '@/lib/admin/admin-session-edge';
-import { internalToolsEnabled, isInternalToolPath } from '@/lib/internal-tools';
+import type { SessionClaims } from '@/lib/auth/session-jwt';
 import { verifySessionToken } from '@/lib/auth/session-jwt';
+import { internalToolsEnabled, isInternalToolPath } from '@/lib/internal-tools';
 
 interface User {
   id: string;
@@ -77,6 +79,21 @@ export async function updateSession(request: NextRequest) {
     isAdminPath &&
     (await isValidAdminSessionCookie(request.cookies.get(ADMIN_COOKIE_NAME)?.value));
 
+  if (isAdminPath && user && !adminSessionValid) {
+    const claims: SessionClaims = {
+      sub: user.id,
+      email: user.email,
+      full_name: 'User',
+      role: user.roles?.[0] ?? 'student',
+    };
+    if (!isLmsClaimsAllowedAdminPanel(claims)) {
+      const url = request.nextUrl.clone();
+      url.pathname = '/dashboard/student';
+      url.search = '';
+      return NextResponse.redirect(url);
+    }
+  }
+
   const protectedPaths = ['/dashboard', '/student', '/instructor'];
   const isProtectedPath =
     protectedPaths.some((path) => pathname.startsWith(path)) ||
@@ -100,11 +117,15 @@ export async function updateSession(request: NextRequest) {
 
   if (isAuthPath && user) {
     const url = request.nextUrl.clone();
+    const claims: SessionClaims = {
+      sub: user.id,
+      email: user.email,
+      full_name: 'User',
+      role: user.roles?.[0] ?? 'student',
+    };
     const next =
       request.nextUrl.searchParams.get('next') ?? request.nextUrl.searchParams.get('redirect');
-    const safePath =
-      next && next.startsWith('/') && !next.startsWith('//') ? next : '/dashboard/student';
-    url.pathname = safePath;
+    url.pathname = getPostLoginRedirectPath(claims, next);
     url.searchParams.delete('next');
     url.searchParams.delete('redirect');
     return NextResponse.redirect(url);

--- a/src/lib/api/middleware.ts
+++ b/src/lib/api/middleware.ts
@@ -7,7 +7,10 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
 import { ADMIN_COOKIE_NAME } from '@/lib/admin/admin-constants';
-import { getPostLoginRedirectPath, isLmsClaimsAllowedAdminPanel } from '@/lib/admin/admin-auth';
+import {
+  getPostLoginRedirectPath,
+  isLmsClaimsAllowedAdminPanel,
+} from '@/lib/admin/admin-panel-access';
 import { isValidAdminSessionCookie } from '@/lib/admin/admin-session-edge';
 import type { SessionClaims } from '@/lib/auth/session-jwt';
 import { verifySessionToken } from '@/lib/auth/session-jwt';

--- a/src/lib/api/middleware.ts
+++ b/src/lib/api/middleware.ts
@@ -42,10 +42,26 @@ async function verifyToken(token: string): Promise<User | null> {
 /**
  * Update session and handle authentication
  */
+/** Legacy WordPress / marketing paths → dashboard student area. */
+function legacyStudentRedirect(pathname: string): string | null {
+  if (pathname === '/student') return '/dashboard/student';
+  if (pathname.startsWith('/student/')) {
+    return `/dashboard${pathname}`;
+  }
+  return null;
+}
+
 export async function updateSession(request: NextRequest) {
-  const response = NextResponse.next({
-    request,
-  });
+  const pathname = request.nextUrl.pathname;
+
+  const studentRedirect = legacyStudentRedirect(pathname);
+  if (studentRedirect) {
+    const url = request.nextUrl.clone();
+    url.pathname = studentRedirect;
+    return NextResponse.redirect(url, 308);
+  }
+
+  const response = NextResponse.next();
 
   const token = request.cookies.get('auth_token')?.value;
 
@@ -66,8 +82,6 @@ export async function updateSession(request: NextRequest) {
       /^\/verify\/credential\/[^/]+(\/?)$/.test(pathname)
     );
   }
-
-  const pathname = request.nextUrl.pathname;
 
   if (isInternalToolPath(pathname) && !internalToolsEnabled()) {
     const url = request.nextUrl.clone();

--- a/src/lib/cec-display.ts
+++ b/src/lib/cec-display.ts
@@ -1,0 +1,55 @@
+import { resolveCecHours } from '@/lib/seed/cec-hours';
+import type { CourseListItem } from '@/lib/wordpress-export-courses';
+import { loadWpExportCourses } from '@/lib/wordpress-export-courses';
+
+/** User-facing CEC label: whole numbers without decimals, halves as one decimal. */
+export function formatCecHoursForDisplay(
+  value: number | string | null | undefined
+): string | null {
+  if (value == null || value === '') return null;
+  const n = typeof value === 'number' ? value : parseFloat(String(value));
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return n % 1 === 0 ? String(Math.trunc(n)) : String(Number(n.toFixed(1)));
+}
+
+let wpCecBySlugCache: Map<string, string> | undefined;
+
+/** Slug → formatted CEC hours from `courses.json` (parsed text/meta when field is null). */
+export function getWpExportCecHoursBySlug(): Map<string, string> {
+  if (wpCecBySlugCache) return wpCecBySlugCache;
+
+  wpCecBySlugCache = new Map();
+  const courses = loadWpExportCourses();
+  if (!courses?.length) return wpCecBySlugCache;
+
+  for (const c of courses) {
+    const hours = resolveCecHours({
+      cec_hours: c.cec_hours,
+      short_description: c.short_description,
+      description: c.description,
+      meta: c.meta,
+    });
+    const label = formatCecHoursForDisplay(hours);
+    if (label) wpCecBySlugCache.set(c.slug.trim().toLowerCase(), label);
+  }
+
+  return wpCecBySlugCache;
+}
+
+export function resolveCecHoursLabelForSlug(
+  slug: string,
+  dbValue: number | string | null | undefined
+): string | null {
+  const fromDb = formatCecHoursForDisplay(dbValue);
+  if (fromDb) return fromDb;
+  return getWpExportCecHoursBySlug().get(slug.trim().toLowerCase()) ?? null;
+}
+
+export function withCecHoursFallback(item: CourseListItem): CourseListItem {
+  const label = resolveCecHoursLabelForSlug(item.slug, item.cec_hours);
+  return label ? { ...item, cec_hours: label } : { ...item, cec_hours: null };
+}
+
+export function withCecHoursFallbackList(items: CourseListItem[]): CourseListItem[] {
+  return items.map(withCecHoursFallback);
+}

--- a/src/lib/checkout-purchase-mode.ts
+++ b/src/lib/checkout-purchase-mode.ts
@@ -1,0 +1,25 @@
+export type CoursePurchaseMode = 'self' | 'team';
+
+export const MIN_TEAM_SEATS = 2;
+export const MAX_TEAM_SEATS = 100;
+
+export function parsePurchaseMode(value: unknown): CoursePurchaseMode {
+  return value === 'team' ? 'team' : 'self';
+}
+
+export function parseTeamSeatCount(value: unknown): number | null {
+  if (value == null) return null;
+  const n = typeof value === 'number' ? value : Number.parseInt(String(value), 10);
+  if (!Number.isFinite(n)) return null;
+  return Math.floor(n);
+}
+
+export function validateTeamSeatCount(seats: number): string | null {
+  if (seats < MIN_TEAM_SEATS) {
+    return `Team purchases need at least ${MIN_TEAM_SEATS} seats (including you).`;
+  }
+  if (seats > MAX_TEAM_SEATS) {
+    return `Team purchases are limited to ${MAX_TEAM_SEATS} seats per order.`;
+  }
+  return null;
+}

--- a/src/lib/checkout-urls.ts
+++ b/src/lib/checkout-urls.ts
@@ -6,11 +6,23 @@ export function buildCourseCheckoutUrls(
   origin: string,
   slug: string,
   learnNextPath?: string | null,
+  options?: { teamSeats?: number },
 ) {
   const base = origin.replace(/\/$/, '');
   const encodedSlug = encodeURIComponent(slug);
   const nextPath = learnNextPath?.startsWith('/') ? learnNextPath : '/dashboard/student';
   const next = encodeURIComponent(nextPath);
+
+  if (options?.teamSeats && options.teamSeats >= 2) {
+    const seats = encodeURIComponent(String(options.teamSeats));
+    const course = encodeURIComponent(slug);
+    return {
+      success_url: `${base}/dashboard/team?session_id={CHECKOUT_SESSION_ID}&from_purchase=1&course=${course}&seats=${seats}`,
+      cancel_url: `${base}/courses/${encodedSlug}`,
+      learn_next_path: `/dashboard/team?from_purchase=1&course=${course}&seats=${seats}`,
+    };
+  }
+
   return {
     success_url: `${base}/courses/${encodedSlug}/payment-success?session_id={CHECKOUT_SESSION_ID}&next=${next}`,
     cancel_url: `${base}/courses/${encodedSlug}`,

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -49,8 +49,23 @@ function createClient() {
   });
 }
 
-export const prisma = globalForPrisma.prisma ?? createClient();
-
-if (process.env.NODE_ENV !== 'production') {
-  globalForPrisma.prisma = prisma;
+function clientHasTeamCoursePurchases(client: PrismaClient): boolean {
+  return Boolean(
+    (client as PrismaClient & { lmsTeamCoursePurchase?: { findMany?: unknown } })
+      .lmsTeamCoursePurchase?.findMany,
+  );
 }
+
+/** Dev HMR can keep a Prisma client generated before new models exist — refresh when stale. */
+function getPrismaClient(): PrismaClient {
+  let client = globalForPrisma.prisma ?? createClient();
+  if (!clientHasTeamCoursePurchases(client)) {
+    client = createClient();
+  }
+  if (process.env.NODE_ENV !== 'production') {
+    globalForPrisma.prisma = client;
+  }
+  return client;
+}
+
+export const prisma = getPrismaClient();

--- a/src/lib/seed/cec-hours.ts
+++ b/src/lib/seed/cec-hours.ts
@@ -57,11 +57,11 @@ export function extractCecHoursFromMeta(meta: unknown): number | null {
 
   if (typeof meta === 'object') {
     const record = meta as Record<string, unknown>;
-    for (const key of CEC_META_KEYS) {
-      if (key in record) {
-        const hours = parsePositiveHours(record[key]);
-        if (hours != null) return hours;
-      }
+    for (const [rawKey, rawValue] of Object.entries(record)) {
+      const key = rawKey.toLowerCase();
+      if (!CEC_META_KEYS.includes(key as (typeof CEC_META_KEYS)[number])) continue;
+      const hours = parsePositiveHours(rawValue);
+      if (hours != null) return hours;
     }
   }
 

--- a/src/lib/seed/cec-hours.ts
+++ b/src/lib/seed/cec-hours.ts
@@ -1,0 +1,110 @@
+/**
+ * Resolve IICRC CEC hours for WooCommerce / LMS course rows.
+ *
+ * Priority: explicit `cec_hours` → Woo meta keys → prose in short_description / description
+ * (e.g. "Continuing Education Credit (CEC) : 3 Hours").
+ */
+
+export const CEC_META_KEYS = [
+  'cec_hours',
+  '_cec_hours',
+  'iicrc_cec',
+  'continuing_education_credits',
+] as const;
+
+/** Common phrasing in CARSI Woo short descriptions. */
+const CEC_TEXT_PATTERNS: RegExp[] = [
+  /Continuing Education Credit\s*\(CEC\)\s*:\s*(\d+(?:\.\d+)?)\s*Hours?/i,
+  /\(CEC\)\s*:\s*(\d+(?:\.\d+)?)\s*Hours?/i,
+  /\(CEC\)\s*:\s*(\d+(?:\.\d+)?)\b/i,
+  /\bCEC\s*:\s*(\d+(?:\.\d+)?)\s*Hours?/i,
+  /(\d+(?:\.\d+)?)\s*IICRC\s+CEC(?:\s+Hours?|\s+Credits?)?/i,
+];
+
+function parsePositiveHours(value: unknown): number | null {
+  if (value == null || value === '') return null;
+  const n = typeof value === 'number' ? value : parseFloat(String(value));
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n;
+}
+
+export function extractCecHoursFromText(text: string | null | undefined): number | null {
+  if (!text?.trim()) return null;
+  for (const pattern of CEC_TEXT_PATTERNS) {
+    const match = pattern.exec(text);
+    if (match?.[1]) {
+      const hours = parsePositiveHours(match[1]);
+      if (hours != null) return hours;
+    }
+  }
+  return null;
+}
+
+/** Read CEC from Woo `meta_data` array (`{ key, value }[]`) or plain object meta. */
+export function extractCecHoursFromMeta(meta: unknown): number | null {
+  if (meta == null) return null;
+
+  if (Array.isArray(meta)) {
+    for (const entry of meta) {
+      if (!entry || typeof entry !== 'object') continue;
+      const key = String((entry as { key?: unknown }).key ?? '').toLowerCase();
+      if (!CEC_META_KEYS.includes(key as (typeof CEC_META_KEYS)[number])) continue;
+      const hours = parsePositiveHours((entry as { value?: unknown }).value);
+      if (hours != null) return hours;
+    }
+    return null;
+  }
+
+  if (typeof meta === 'object') {
+    const record = meta as Record<string, unknown>;
+    for (const key of CEC_META_KEYS) {
+      if (key in record) {
+        const hours = parsePositiveHours(record[key]);
+        if (hours != null) return hours;
+      }
+    }
+  }
+
+  return null;
+}
+
+export type CecResolvable = {
+  cec_hours?: number | null;
+  short_description?: string | null;
+  description?: string | null;
+  meta?: unknown;
+};
+
+/** Best available CEC hours for a WP-export or catalog-shaped row. */
+export function resolveCecHours(row: CecResolvable): number | null {
+  const explicit = parsePositiveHours(row.cec_hours);
+  if (explicit != null) return explicit;
+
+  const fromMeta = extractCecHoursFromMeta(row.meta);
+  if (fromMeta != null) return fromMeta;
+
+  const text = [row.short_description, row.description].filter(Boolean).join('\n');
+  return extractCecHoursFromText(text);
+}
+
+export function enrichCourseWithCecHours<T extends CecResolvable>(
+  row: T
+): T & { cec_hours: number | null } {
+  return { ...row, cec_hours: resolveCecHours(row) };
+}
+
+/** Catalog JSON uses camelCase `cecHours`. */
+export function resolveCatalogCecHours(course: {
+  cecHours?: number | null;
+  shortDescription?: string | null;
+  description?: string | null;
+  meta?: unknown;
+}): number | null {
+  const explicit = parsePositiveHours(course.cecHours);
+  if (explicit != null) return explicit;
+  return resolveCecHours({
+    short_description: course.shortDescription,
+    description: course.description,
+    meta: course.meta,
+  });
+}

--- a/src/lib/seed/wp-export-published-import-slugs.ts
+++ b/src/lib/seed/wp-export-published-import-slugs.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { isCoursesCatalogFile } from './courses-catalog-types';
+import { enrichCourseWithCecHours } from './cec-hours';
 import { readWpExportCoursesJsonOrThrow } from './wp-export-courses-json';
 
 const HREF_RE = /carsi\.com\.au\/courses\/([^/"']+)\//g;
@@ -87,10 +88,12 @@ export function getPublishedWpImportRows(appRoot: string): {
   const excludeSlugs = buildSeedExclusionWpSlugs(seedSlugs, seedTitles, wpRaw);
 
   const wp = JSON.parse(wpRaw) as WpExportCourseRow[];
-  const rows = wp.filter(
-    (c) =>
-      !excludeSlugs.has(c.slug) && (c.status ?? '').trim().toLowerCase() === 'published'
-  );
+  const rows = wp
+    .filter(
+      (c) =>
+        !excludeSlugs.has(c.slug) && (c.status ?? '').trim().toLowerCase() === 'published'
+    )
+    .map((c) => enrichCourseWithCecHours(c));
 
   return { rows, excludeSlugs };
 }

--- a/src/lib/server/email-templates.ts
+++ b/src/lib/server/email-templates.ts
@@ -294,6 +294,65 @@ export function renderEnrollmentWelcomeEmail(params: {
   );
 }
 
+export function renderTeamMemberAddedEmail(params: {
+  appOrigin: string;
+  memberName: string;
+  inviterName: string;
+  teamName: string;
+  courseTitles: string[];
+  loginUrl: string;
+  memberEmail: string;
+  temporaryPassword?: string;
+}): RenderedEmail {
+  const courseList =
+    params.courseTitles.length === 1
+      ? params.courseTitles[0]!
+      : params.courseTitles.map((t) => `• ${t}`).join('\n');
+
+  const details: CarsiEmailDetail[] = [
+    {
+      label: params.courseTitles.length === 1 ? 'Course' : 'Courses',
+      value: courseList,
+    },
+    { label: 'Team', value: params.teamName },
+    { label: 'Added by', value: params.inviterName },
+    { label: 'Sign-in email', value: params.memberEmail },
+  ];
+  if (params.temporaryPassword) {
+    details.push({ label: 'Your password', value: params.temporaryPassword });
+  }
+
+  const coursePhrase =
+    params.courseTitles.length === 1
+      ? params.courseTitles[0]!
+      : `these ${params.courseTitles.length} courses`;
+
+  const paragraphs = [
+    `${params.inviterName} gave you access to ${coursePhrase} on CARSI.`,
+    'Use your sign-in details below — your password is only for you. Change it after your first login if you like.',
+  ];
+
+  const subjectCourse =
+    params.courseTitles.length === 1
+      ? params.courseTitles[0]!
+      : `${params.courseTitles.length} courses`;
+
+  return render(
+    {
+      appOrigin: params.appOrigin,
+      preheader: `${params.inviterName} added you to ${subjectCourse}`,
+      eyebrow: 'Course access',
+      title: 'Your course access is ready',
+      greeting: `Hi ${params.memberName},`,
+      paragraphs,
+      details,
+      cta: { label: 'Sign in & start learning', href: params.loginUrl },
+      noteHtml: `Sign in, then open ${brandLink(`${params.appOrigin}/dashboard/student`, 'My Learning')} — only the course(s) listed above are on your account.`,
+    },
+    `Hi ${params.memberName},\n\n${params.inviterName} gave you access on CARSI (${params.teamName}):\n\n${params.courseTitles.map((t) => `- ${t}`).join('\n')}\n\nSign-in email: ${params.memberEmail}\nYour password: ${params.temporaryPassword ?? '(ask your team owner)'}\n\nSign in: ${params.loginUrl}`,
+  );
+}
+
 export function renderContactNotificationEmail(params: {
   appOrigin: string;
   ticketRef: string;

--- a/src/lib/server/email-templates.ts
+++ b/src/lib/server/email-templates.ts
@@ -17,8 +17,7 @@ export const BRAND = {
   text: 'rgba(255, 255, 255, 0.95)',
   textMuted: 'rgba(255, 255, 255, 0.45)',
   textDim: 'rgba(255, 255, 255, 0.35)',
-  font:
-    "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
+  font: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
 } as const;
 
 export function escapeHtml(s: string): string {
@@ -129,7 +128,6 @@ export function buildCarsiEmailHtml(options: CarsiEmailContent): string {
         </td>
       </tr>`
     : '';
-
 
   const ctaBlock = options.cta
     ? `

--- a/src/lib/server/email-templates.ts
+++ b/src/lib/server/email-templates.ts
@@ -52,7 +52,7 @@ export function buildCarsiWordmarkHtml(appOrigin: string): string {
     </p>`;
 }
 
-export type CarsiEmailDetail = { label: string; value: string };
+export type CarsiEmailDetail = { label: string; value: string; valueHtml?: string };
 
 export type CarsiEmailContent = {
   appOrigin: string;
@@ -107,7 +107,7 @@ export function buildCarsiEmailHtml(options: CarsiEmailContent): string {
                 ${escapeHtml(d.label)}
               </td>
               <td style="padding: 12px 14px; font-family: ${BRAND.font}; font-size: 14px; line-height: 1.5; color: ${BRAND.text}; vertical-align: top; border-bottom: 1px solid ${BRAND.cardBorder};">
-                ${escapeHtml(d.value)}
+                ${d.valueHtml ?? escapeHtml(d.value)}
               </td>
             </tr>`
               )
@@ -308,11 +308,16 @@ export function renderTeamMemberAddedEmail(params: {
     params.courseTitles.length === 1
       ? params.courseTitles[0]!
       : params.courseTitles.map((t) => `• ${t}`).join('\n');
+  const courseListHtml =
+    params.courseTitles.length === 1
+      ? escapeHtml(params.courseTitles[0]!)
+      : params.courseTitles.map((t) => `• ${escapeHtml(t)}`).join('<br>');
 
   const details: CarsiEmailDetail[] = [
     {
       label: params.courseTitles.length === 1 ? 'Course' : 'Courses',
       value: courseList,
+      valueHtml: courseListHtml,
     },
     { label: 'Team', value: params.teamName },
     { label: 'Added by', value: params.inviterName },

--- a/src/lib/server/enrollment-service.ts
+++ b/src/lib/server/enrollment-service.ts
@@ -50,6 +50,56 @@ async function lessonTotalsForCourse(courseId: string): Promise<{ ids: string[];
   return { ids, total: ids.length };
 }
 
+/** Admin/support: mark every lesson in an enrollment complete and sync enrollment status. */
+export async function forceCompleteEnrollment(
+  enrollmentId: string,
+  studentId: string,
+): Promise<{ lessonsMarked: number }> {
+  const en = await prisma.lmsEnrollment.findFirst({
+    where: { id: enrollmentId, studentId },
+    select: { id: true, studentId: true, courseId: true },
+  });
+  if (!en) throw new Error('ENROLLMENT_NOT_FOUND');
+
+  const { ids, total } = await lessonTotalsForCourse(en.courseId);
+  const now = new Date();
+
+  if (total === 0) {
+    await prisma.lmsEnrollment.update({
+      where: { id: en.id },
+      data: { status: 'completed', completedAt: now },
+    });
+    return { lessonsMarked: 0 };
+  }
+
+  await prisma.$transaction([
+    ...ids.map((lessonId) =>
+      prisma.lmsLessonProgress.upsert({
+        where: { studentId_lessonId: { studentId: en.studentId, lessonId } },
+        create: {
+          studentId: en.studentId,
+          lessonId,
+          completed: true,
+          completedAt: now,
+          lastAccessedAt: now,
+        },
+        update: {
+          completed: true,
+          completedAt: now,
+          lastAccessedAt: now,
+        },
+      }),
+    ),
+    prisma.lmsEnrollment.update({
+      where: { id: en.id },
+      data: { lastAccessedLessonId: ids[ids.length - 1]! },
+    }),
+  ]);
+
+  await syncEnrollmentCompletion(en.id, en.studentId, en.courseId);
+  return { lessonsMarked: total };
+}
+
 export async function syncEnrollmentCompletion(
   enrollmentId: string,
   studentId: string,

--- a/src/lib/server/enrollment-service.ts
+++ b/src/lib/server/enrollment-service.ts
@@ -65,10 +65,7 @@ export async function forceCompleteEnrollment(
   const now = new Date();
 
   if (total === 0) {
-    await prisma.lmsEnrollment.update({
-      where: { id: en.id },
-      data: { status: 'completed', completedAt: now },
-    });
+    await syncEnrollmentCompletion(en.id, en.studentId, en.courseId);
     return { lessonsMarked: 0 };
   }
 

--- a/src/lib/server/learner-dashboard-data.ts
+++ b/src/lib/server/learner-dashboard-data.ts
@@ -1,5 +1,5 @@
-import { normalizePublicAssetUrl } from '@/lib/remote-image';
 import { prisma } from '@/lib/prisma';
+import { normalizePublicAssetUrl } from '@/lib/remote-image';
 
 /** Client / API shape for `EnrolledCourseList` and enrollments/me. */
 export interface EnrollmentDto {
@@ -101,7 +101,7 @@ function mapEnrollmentRow(
       : Math.min(100, Math.round((completed / total) * 100));
 
   const lastId = e.lastAccessedLessonId;
-  const lastTitle = lastId ? lessonTitleById.get(lastId) ?? null : null;
+  const lastTitle = lastId ? (lessonTitleById.get(lastId) ?? null) : null;
 
   return {
     id: e.id,
@@ -238,7 +238,10 @@ export async function getResumeSnapshotForStudent(userId: string): Promise<Resum
       orderBy: { enrolledAt: 'desc' },
     });
 
-    const lessonMeta = new Map<string, { title: string; courseSlug: string; courseTitle: string }>();
+    const lessonMeta = new Map<
+      string,
+      { title: string; courseSlug: string; courseTitle: string }
+    >();
     const allLessonIds: string[] = [];
     for (const e of rows) {
       const slug = e.course.slug;

--- a/src/lib/server/local-course-checkout.ts
+++ b/src/lib/server/local-course-checkout.ts
@@ -50,6 +50,10 @@ export async function createStripeCheckoutForCourse(params: {
   /** Optional Stripe metadata (e.g. discount_id). */
   extra_metadata?: Record<string, string>;
   guest_checkout?: boolean;
+  /** Seats for team purchase (line item quantity). */
+  quantity?: number;
+  purchase_mode?: 'self' | 'team';
+  team_seat_count?: number;
 }): Promise<{ checkout_url: string }> {
   const {
     slug,
@@ -61,6 +65,9 @@ export async function createStripeCheckoutForCourse(params: {
     unit_amount_cents,
     extra_metadata,
     guest_checkout,
+    quantity = 1,
+    purchase_mode = 'self',
+    team_seat_count,
   } = params;
 
   const priceNum = Number(course.price_aud);
@@ -72,7 +79,15 @@ export async function createStripeCheckoutForCourse(params: {
     throw new Error('INVALID_AMOUNT');
   }
 
+  const seatQty = Math.max(1, Math.min(100, Math.floor(quantity)));
+  const isTeam = purchase_mode === 'team' && seatQty > 1;
+  const teamSeats = isTeam ? (team_seat_count ?? seatQty) : undefined;
+
   const stripe = getStripeClient();
+
+  const productName = isTeam
+    ? `${course.title || slug} — team (${seatQty} seats)`
+    : course.title || slug;
 
   const session = await stripe.checkout.sessions.create({
     mode: 'payment',
@@ -82,19 +97,23 @@ export async function createStripeCheckoutForCourse(params: {
     metadata: {
       course_slug: slug,
       source: 'carsi-next-local-checkout',
+      purchase_mode: isTeam ? 'team' : 'self',
+      ...(teamSeats != null ? { team_seat_count: String(teamSeats) } : {}),
       ...(student_id ? { student_id } : {}),
       ...(guest_checkout ? { guest_checkout: 'true' } : {}),
       ...(extra_metadata ?? {}),
     },
     line_items: [
       {
-        quantity: 1,
+        quantity: seatQty,
         price_data: {
           currency: 'aud',
           unit_amount: unitAmount,
           product_data: {
-            name: course.title || slug,
-            description: course.short_description?.slice(0, 500) || undefined,
+            name: productName,
+            description: isTeam
+              ? `${seatQty} learner seats for this course`
+              : course.short_description?.slice(0, 500) || undefined,
           },
         },
       },

--- a/src/lib/server/member-temp-password.ts
+++ b/src/lib/server/member-temp-password.ts
@@ -1,0 +1,12 @@
+import { randomBytes } from 'node:crypto';
+
+/** Human-friendly temporary password for provisioned team members (email delivery). */
+export function generateMemberTempPassword(): string {
+  const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789';
+  const bytes = randomBytes(10);
+  let out = '';
+  for (let i = 0; i < 10; i++) {
+    out += alphabet[bytes[i]! % alphabet.length];
+  }
+  return `Carsi-${out}`;
+}

--- a/src/lib/server/proxy-fetch-response.ts
+++ b/src/lib/server/proxy-fetch-response.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+/** Safe proxy of an upstream `fetch` Response for App Router route handlers. */
+export async function nextResponseFromFetch(res: Response): Promise<NextResponse> {
+  const contentType = res.headers.get('content-type') ?? 'application/json';
+  const body = new Uint8Array(await res.arrayBuffer());
+  return new NextResponse(body, {
+    status: res.status,
+    headers: { 'content-type': contentType },
+  });
+}

--- a/src/lib/server/public-courses-list.ts
+++ b/src/lib/server/public-courses-list.ts
@@ -1,4 +1,5 @@
 import type { Prisma } from '@/generated/prisma/client';
+import { resolveCecHoursLabelForSlug } from '@/lib/cec-display';
 import { prisma } from '@/lib/prisma';
 import { normalizePublicAssetUrl } from '@/lib/remote-image';
 import type { CourseListItem, WpExportCourse } from '@/lib/wordpress-export-courses';
@@ -50,7 +51,7 @@ function mapDashboardCourseRow(c: {
     instructor: null,
     catalog_status: st === 'draft' ? 'draft' : 'published',
     module_count: c._count.modules,
-    cec_hours: c.cecHours != null ? String(c.cecHours) : null,
+    cec_hours: resolveCecHoursLabelForSlug(c.slug, c.cecHours),
     duration_hours: c.durationHours != null ? String(c.durationHours) : null,
   };
 }
@@ -328,7 +329,7 @@ export async function getPublishedCourseDetailBySlugFromDatabase(slug: string) {
     level: row.level ?? null,
     category: row.category ?? null,
     iicrc_discipline: row.iicrcDiscipline ?? null,
-    cec_hours: row.cecHours != null ? String(row.cecHours) : null,
+    cec_hours: resolveCecHoursLabelForSlug(row.slug, row.cecHours),
     duration_hours: row.durationHours != null ? String(row.durationHours) : null,
     thumbnail_url: normalizePublicAssetUrl(row.thumbnailUrl),
     module_count: row._count.modules,

--- a/src/lib/server/public-courses-list.ts
+++ b/src/lib/server/public-courses-list.ts
@@ -144,7 +144,7 @@ function mapLmsCourseToPublicListItem(c: LmsCoursePublicListRow): CourseListItem
     module_count: c._count.modules,
     updated_at: c.updatedAt.toISOString(),
     instructor: c.instructor?.fullName ? { full_name: c.instructor.fullName } : null,
-    cec_hours: c.cecHours != null ? String(c.cecHours) : null,
+    cec_hours: resolveCecHoursLabelForSlug(c.slug, c.cecHours),
     duration_hours: c.durationHours != null ? String(c.durationHours) : null,
   };
 }

--- a/src/lib/server/team-api-serialize.ts
+++ b/src/lib/server/team-api-serialize.ts
@@ -1,0 +1,80 @@
+import { prisma } from '@/lib/prisma';
+import {
+  getTeamCoursePurchases,
+  getTeamCourseSeatPools,
+} from '@/lib/server/team-course-seats';
+import { countTeamSeatsUsed, repairAndGetTeamForUser } from '@/lib/server/teams';
+
+type TeamRecord = NonNullable<Awaited<ReturnType<typeof repairAndGetTeamForUser>>>;
+
+export async function serializeTeamForClient(team: TeamRecord, claimsSub: string) {
+  const isOwner = team.ownerId === claimsSub;
+  const ownerMember = team.members.find((m) => m.userId === team.ownerId);
+
+  if (!isOwner) {
+    const teamRef = `team:${team.id}`;
+    const assigned = await prisma.lmsEnrollment.findMany({
+      where: {
+        studentId: claimsSub,
+        paymentReference: teamRef,
+        status: { notIn: ['cancelled'] },
+      },
+      include: { course: { select: { slug: true, title: true } } },
+      orderBy: { enrolledAt: 'asc' },
+    });
+
+    return {
+      id: team.id,
+      name: team.name,
+      slug: team.slug,
+      bundle_tier: team.bundleTier,
+      is_owner: false,
+      added_by: {
+        full_name: ownerMember?.user.fullName ?? null,
+        email: ownerMember?.user.email ?? '',
+      },
+      my_team_courses: assigned.map((e) => ({
+        slug: e.course.slug.trim().toLowerCase(),
+        title: e.course.title,
+      })),
+    };
+  }
+
+  const seatsUsed = await countTeamSeatsUsed(team.id);
+  const coursePurchases = await getTeamCoursePurchases(team.id);
+  const courseSeatPools = await getTeamCourseSeatPools(team.id);
+
+  return {
+    id: team.id,
+    name: team.name,
+    slug: team.slug,
+    bundle_tier: team.bundleTier,
+    course_slug: team.courseSlug,
+    seat_limit: team.seatLimit,
+    seats_used: seatsUsed,
+    owner_id: team.ownerId,
+    is_owner: true,
+    course_purchases: coursePurchases,
+    course_seat_pools: courseSeatPools.map((p) => ({
+      course_slug: p.course_slug,
+      course_title: p.course_title,
+      seat_limit: p.seat_limit,
+      seats_used: p.seats_used,
+      seats_remaining: p.seats_remaining,
+      purchase_count: p.purchase_count,
+      purchases: p.purchases,
+    })),
+    members: team.members.map((m) => ({
+      user_id: m.userId,
+      role: m.role,
+      email: m.user.email,
+      full_name: m.user.fullName,
+    })),
+    pending_invites: team.invites.map((i) => ({
+      id: i.id,
+      email: i.email,
+      role: i.role,
+      expires_at: i.expiresAt.toISOString(),
+    })),
+  };
+}

--- a/src/lib/server/team-api-serialize.ts
+++ b/src/lib/server/team-api-serialize.ts
@@ -40,9 +40,11 @@ export async function serializeTeamForClient(team: TeamRecord, claimsSub: string
     };
   }
 
-  const seatsUsed = await countTeamSeatsUsed(team.id);
-  const coursePurchases = await getTeamCoursePurchases(team.id);
-  const courseSeatPools = await getTeamCourseSeatPools(team.id);
+  const [seatsUsed, coursePurchases, courseSeatPools] = await Promise.all([
+    countTeamSeatsUsed(team.id),
+    getTeamCoursePurchases(team.id),
+    getTeamCourseSeatPools(team.id),
+  ]);
 
   return {
     id: team.id,

--- a/src/lib/server/team-course-purchase-db.ts
+++ b/src/lib/server/team-course-purchase-db.ts
@@ -1,0 +1,163 @@
+import { randomUUID } from 'node:crypto';
+
+import { prisma } from '@/lib/prisma';
+
+export type TeamCoursePurchaseRecord = {
+  id: string;
+  teamId: string;
+  courseSlug: string;
+  seatLimit: number;
+  paymentReference: string | null;
+  purchasedAt: Date;
+};
+
+function purchaseDelegateAvailable(): boolean {
+  const delegate = (
+    prisma as { lmsTeamCoursePurchase?: { findMany?: unknown } }
+  ).lmsTeamCoursePurchase;
+  return typeof delegate?.findMany === 'function';
+}
+
+function mapRaw(row: {
+  id: string;
+  team_id: string;
+  course_slug: string;
+  seat_limit: number;
+  payment_reference: string | null;
+  purchased_at: Date;
+}): TeamCoursePurchaseRecord {
+  return {
+    id: row.id,
+    teamId: row.team_id,
+    courseSlug: row.course_slug,
+    seatLimit: row.seat_limit,
+    paymentReference: row.payment_reference,
+    purchasedAt: row.purchased_at,
+  };
+}
+
+export async function findTeamCoursePurchasesByTeamId(
+  teamId: string,
+): Promise<TeamCoursePurchaseRecord[]> {
+  if (purchaseDelegateAvailable()) {
+    const rows = await prisma.lmsTeamCoursePurchase.findMany({
+      where: { teamId },
+      orderBy: { purchasedAt: 'asc' },
+    });
+    return rows.map((r) => ({
+      id: r.id,
+      teamId: r.teamId,
+      courseSlug: r.courseSlug,
+      seatLimit: r.seatLimit,
+      paymentReference: r.paymentReference,
+      purchasedAt: r.purchasedAt,
+    }));
+  }
+
+  const rows = await prisma.$queryRaw<
+    {
+      id: string;
+      team_id: string;
+      course_slug: string;
+      seat_limit: number;
+      payment_reference: string | null;
+      purchased_at: Date;
+    }[]
+  >`
+    SELECT id, team_id, course_slug, seat_limit, payment_reference, purchased_at
+    FROM lms_team_course_purchases
+    WHERE team_id = ${teamId}::uuid
+    ORDER BY purchased_at ASC
+  `;
+  return rows.map(mapRaw);
+}
+
+export async function findTeamCoursePurchaseByPaymentReference(
+  paymentReference: string,
+): Promise<TeamCoursePurchaseRecord | null> {
+  const ref = paymentReference.trim();
+  if (!ref) return null;
+
+  if (purchaseDelegateAvailable()) {
+    const row = await prisma.lmsTeamCoursePurchase.findFirst({
+      where: { paymentReference: ref },
+    });
+    if (!row) return null;
+    return {
+      id: row.id,
+      teamId: row.teamId,
+      courseSlug: row.courseSlug,
+      seatLimit: row.seatLimit,
+      paymentReference: row.paymentReference,
+      purchasedAt: row.purchasedAt,
+    };
+  }
+
+  const rows = await prisma.$queryRaw<
+    {
+      id: string;
+      team_id: string;
+      course_slug: string;
+      seat_limit: number;
+      payment_reference: string | null;
+      purchased_at: Date;
+    }[]
+  >`
+    SELECT id, team_id, course_slug, seat_limit, payment_reference, purchased_at
+    FROM lms_team_course_purchases
+    WHERE payment_reference = ${ref}
+    LIMIT 1
+  `;
+  const row = rows[0];
+  return row ? mapRaw(row) : null;
+}
+
+export async function insertTeamCoursePurchase(params: {
+  teamId: string;
+  courseSlug: string;
+  seatLimit: number;
+  paymentReference?: string;
+}): Promise<void> {
+  const slug = params.courseSlug.trim().toLowerCase();
+  const ref = params.paymentReference?.trim() || null;
+  const id = randomUUID();
+
+  if (purchaseDelegateAvailable()) {
+    await prisma.lmsTeamCoursePurchase.create({
+      data: {
+        teamId: params.teamId,
+        courseSlug: slug,
+        seatLimit: params.seatLimit,
+        paymentReference: ref,
+      },
+    });
+    return;
+  }
+
+  await prisma.$executeRaw`
+    INSERT INTO lms_team_course_purchases (id, team_id, course_slug, seat_limit, payment_reference, purchased_at)
+    VALUES (${id}::uuid, ${params.teamId}::uuid, ${slug}, ${params.seatLimit}, ${ref}, NOW())
+  `;
+}
+
+export async function sumTeamCoursePurchaseSeats(teamId: string): Promise<number> {
+  if (purchaseDelegateAvailable()) {
+    const total = await prisma.lmsTeamCoursePurchase.aggregate({
+      where: { teamId },
+      _sum: { seatLimit: true },
+    });
+    return total._sum.seatLimit ?? 0;
+  }
+
+  const rows = await prisma.$queryRaw<{ total: number | null }[]>`
+    SELECT COALESCE(SUM(seat_limit), 0)::int AS total
+    FROM lms_team_course_purchases
+    WHERE team_id = ${teamId}::uuid
+  `;
+  return rows[0]?.total ?? 0;
+}
+
+export async function listTeamCoursePurchaseSlugs(teamId: string): Promise<string[]> {
+  const purchases = await findTeamCoursePurchasesByTeamId(teamId);
+  return purchases.map((p) => p.courseSlug.trim().toLowerCase());
+}

--- a/src/lib/server/team-course-purchase.ts
+++ b/src/lib/server/team-course-purchase.ts
@@ -1,0 +1,170 @@
+import type { SessionClaims } from '@/lib/auth/session-jwt';
+import { prisma } from '@/lib/prisma';
+import { enrollStudentInCourse } from '@/lib/server/enrollment-service';
+import { sessionClaimsForUserId } from '@/lib/server/lms-auth';
+import { addTeamCoursePurchase } from '@/lib/server/team-course-seats';
+import { sumTeamCoursePurchaseSeats } from '@/lib/server/team-course-purchase-db';
+import { writeTeamCourseSlug } from '@/lib/server/team-course-slug-db';
+import { createUniqueTeamSlug } from '@/lib/server/teams';
+
+const COURSE_BUNDLE_TIER = 'course_purchase';
+
+export function buildTeamDashboardUrl(
+  origin: string,
+  params: { courseSlug: string; seats: number; fromPurchase?: boolean },
+): string {
+  const base = origin.replace(/\/$/, '');
+  const q = new URLSearchParams({
+    from_purchase: params.fromPurchase !== false ? '1' : '0',
+    course: params.courseSlug,
+    seats: String(params.seats),
+  });
+  return `${base}/dashboard/team?${q.toString()}`;
+}
+
+/**
+ * After a multi-seat course purchase: enrol the buyer and provision a team with seat_limit = seats.
+ */
+export async function provisionTeamCoursePurchase(params: {
+  ownerId: string;
+  ownerEmail: string;
+  ownerName: string | null;
+  courseSlug: string;
+  seatCount: number;
+  paymentReference: string;
+}): Promise<{ teamId: string; teamSlug: string }> {
+  const { ownerId, ownerEmail, ownerName, courseSlug, seatCount, paymentReference } = params;
+
+  const existingMembership = await prisma.lmsTeamMember.findFirst({
+    where: { userId: ownerId },
+    include: { team: true },
+  });
+
+  if (existingMembership) {
+    const team = existingMembership.team;
+    if (team.ownerId !== ownerId) {
+      throw new Error('ALREADY_ON_TEAM');
+    }
+    await addTeamCoursePurchase({
+      teamId: team.id,
+      courseSlug,
+      seatLimit: seatCount,
+      paymentReference,
+    });
+    const totalSeats = await sumTeamCoursePurchaseSeats(team.id);
+    await prisma.lmsTeam.update({
+      where: { id: team.id },
+      data: {
+        seatLimit: totalSeats > 0 ? totalSeats : seatCount,
+        bundleTier: COURSE_BUNDLE_TIER,
+      },
+    });
+    await writeTeamCourseSlug(team.id, courseSlug);
+    return { teamId: team.id, teamSlug: team.slug };
+  }
+
+  const name = 'My team';
+  const slug = await createUniqueTeamSlug(name);
+
+  const team = await prisma.lmsTeam.create({
+    data: {
+      name,
+      slug,
+      ownerId,
+      bundleTier: COURSE_BUNDLE_TIER,
+      seatLimit: seatCount,
+      members: {
+        create: { userId: ownerId, role: 'owner' },
+      },
+    },
+    select: { id: true, slug: true },
+  });
+
+  await writeTeamCourseSlug(team.id, courseSlug);
+  await addTeamCoursePurchase({
+    teamId: team.id,
+    courseSlug,
+    seatLimit: seatCount,
+    paymentReference,
+  });
+
+  return { teamId: team.id, teamSlug: team.slug };
+}
+
+export async function fulfillCourseCheckoutForUser(params: {
+  claims: SessionClaims;
+  courseSlug: string;
+  paymentReference: string;
+  purchaseMode: 'self' | 'team';
+  teamSeatCount?: number;
+}): Promise<{
+  kind: 'self' | 'team';
+  enrollmentId?: string;
+  courseId?: string;
+  teamSlug?: string;
+  redirectPath: string;
+  alreadyEnrolled: boolean;
+}> {
+  const { claims, courseSlug, paymentReference, purchaseMode, teamSeatCount } = params;
+
+  const result = await enrollStudentInCourse(claims, courseSlug, paymentReference);
+  const alreadyEnrolled = result === 'already_enrolled';
+
+  if (purchaseMode !== 'team' || !teamSeatCount || teamSeatCount < 2) {
+    const { getFirstLessonLearnPath } = await import('@/lib/server/first-lesson');
+    const learnPath = (await getFirstLessonLearnPath(courseSlug)) ?? '/dashboard/student';
+    return {
+      kind: 'self',
+      alreadyEnrolled,
+      enrollmentId: alreadyEnrolled ? undefined : result.enrollmentId,
+      courseId: alreadyEnrolled ? undefined : result.courseId,
+      redirectPath: learnPath,
+    };
+  }
+
+  const user = await prisma.lmsUser.findUnique({
+    where: { id: claims.sub },
+    select: { email: true, fullName: true },
+  });
+  if (!user) throw new Error('USER_NOT_FOUND');
+
+  const { teamSlug } = await provisionTeamCoursePurchase({
+    ownerId: claims.sub,
+    ownerEmail: user.email,
+    ownerName: user.fullName,
+    courseSlug,
+    seatCount: teamSeatCount,
+    paymentReference,
+  });
+
+  return {
+    kind: 'team',
+    alreadyEnrolled,
+    teamSlug,
+    enrollmentId: alreadyEnrolled ? undefined : result.enrollmentId,
+    courseId: alreadyEnrolled ? undefined : result.courseId,
+    redirectPath: `/dashboard/team?from_purchase=1&course=${encodeURIComponent(courseSlug)}&seats=${teamSeatCount}`,
+  };
+}
+
+/** Enrol a team member in the team's purchased course when they accept an invite. */
+export async function enrollTeamMemberInPurchasedCourse(
+  userId: string,
+  teamId: string,
+): Promise<void> {
+  const { readTeamCourseSlug } = await import('@/lib/server/team-course-slug-db');
+  const slug = await readTeamCourseSlug(teamId);
+  if (!slug) return;
+
+  const claims = await sessionClaimsForUserId(userId);
+  if (!claims) return;
+
+  try {
+    await enrollStudentInCourse(claims, slug, `team:${teamId}`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg !== 'COURSE_NOT_FOUND') {
+      console.error('[team-course-purchase] member enrol', e);
+    }
+  }
+}

--- a/src/lib/server/team-course-purchase.ts
+++ b/src/lib/server/team-course-purchase.ts
@@ -1,10 +1,8 @@
+import { Prisma } from '@/generated/prisma/client';
 import type { SessionClaims } from '@/lib/auth/session-jwt';
 import { prisma } from '@/lib/prisma';
 import { enrollStudentInCourse } from '@/lib/server/enrollment-service';
 import { sessionClaimsForUserId } from '@/lib/server/lms-auth';
-import { addTeamCoursePurchase } from '@/lib/server/team-course-seats';
-import { sumTeamCoursePurchaseSeats } from '@/lib/server/team-course-purchase-db';
-import { writeTeamCourseSlug } from '@/lib/server/team-course-slug-db';
 import { createUniqueTeamSlug } from '@/lib/server/teams';
 
 const COURSE_BUNDLE_TIER = 'course_purchase';
@@ -22,6 +20,65 @@ export function buildTeamDashboardUrl(
   return `${base}/dashboard/team?${q.toString()}`;
 }
 
+async function writeTeamCourseSlugTx(
+  tx: Prisma.TransactionClient,
+  teamId: string,
+  courseSlug: string,
+): Promise<void> {
+  const slug = courseSlug.trim().toLowerCase();
+  try {
+    await tx.lmsTeam.update({
+      where: { id: teamId },
+      data: { courseSlug: slug },
+    });
+  } catch {
+    await tx.$executeRaw`
+      UPDATE lms_teams SET course_slug = ${slug} WHERE id = ${teamId}::uuid
+    `;
+  }
+}
+
+async function insertTeamCoursePurchaseTx(
+  tx: Prisma.TransactionClient,
+  params: {
+    teamId: string;
+    courseSlug: string;
+    seatLimit: number;
+    paymentReference?: string;
+  },
+): Promise<boolean> {
+  const slug = params.courseSlug.trim().toLowerCase();
+  const ref = params.paymentReference?.trim() || null;
+
+  if (ref) {
+    const existing = await tx.lmsTeamCoursePurchase.findFirst({
+      where: { paymentReference: ref },
+    });
+    if (existing) return false;
+  }
+
+  await tx.lmsTeamCoursePurchase.create({
+    data: {
+      teamId: params.teamId,
+      courseSlug: slug,
+      seatLimit: params.seatLimit,
+      paymentReference: ref,
+    },
+  });
+  return true;
+}
+
+async function sumTeamCoursePurchaseSeatsTx(
+  tx: Prisma.TransactionClient,
+  teamId: string,
+): Promise<number> {
+  const total = await tx.lmsTeamCoursePurchase.aggregate({
+    where: { teamId },
+    _sum: { seatLimit: true },
+  });
+  return total._sum.seatLimit ?? 0;
+}
+
 /**
  * After a multi-seat course purchase: enrol the buyer and provision a team with seat_limit = seats.
  */
@@ -33,62 +90,66 @@ export async function provisionTeamCoursePurchase(params: {
   seatCount: number;
   paymentReference: string;
 }): Promise<{ teamId: string; teamSlug: string }> {
-  const { ownerId, ownerEmail, ownerName, courseSlug, seatCount, paymentReference } = params;
+  const { ownerId, courseSlug, seatCount, paymentReference } = params;
 
-  const existingMembership = await prisma.lmsTeamMember.findFirst({
-    where: { userId: ownerId },
-    include: { team: true },
-  });
+  return prisma.$transaction(async (tx) => {
+    const existingMembership = await tx.lmsTeamMember.findFirst({
+      where: { userId: ownerId },
+      include: { team: true },
+    });
 
-  if (existingMembership) {
-    const team = existingMembership.team;
-    if (team.ownerId !== ownerId) {
-      throw new Error('ALREADY_ON_TEAM');
+    if (existingMembership) {
+      const team = existingMembership.team;
+      if (team.ownerId !== ownerId) {
+        throw new Error('ALREADY_ON_TEAM');
+      }
+
+      await insertTeamCoursePurchaseTx(tx, {
+        teamId: team.id,
+        courseSlug,
+        seatLimit: seatCount,
+        paymentReference,
+      });
+
+      const totalSeats = await sumTeamCoursePurchaseSeatsTx(tx, team.id);
+      await tx.lmsTeam.update({
+        where: { id: team.id },
+        data: {
+          seatLimit: totalSeats > 0 ? totalSeats : seatCount,
+          bundleTier: COURSE_BUNDLE_TIER,
+        },
+      });
+      await writeTeamCourseSlugTx(tx, team.id, courseSlug);
+      return { teamId: team.id, teamSlug: team.slug };
     }
-    await addTeamCoursePurchase({
+
+    const name = 'My team';
+    const slug = await createUniqueTeamSlug(name);
+
+    const team = await tx.lmsTeam.create({
+      data: {
+        name,
+        slug,
+        ownerId,
+        bundleTier: COURSE_BUNDLE_TIER,
+        seatLimit: seatCount,
+        members: {
+          create: { userId: ownerId, role: 'owner' },
+        },
+      },
+      select: { id: true, slug: true },
+    });
+
+    await writeTeamCourseSlugTx(tx, team.id, courseSlug);
+    await insertTeamCoursePurchaseTx(tx, {
       teamId: team.id,
       courseSlug,
       seatLimit: seatCount,
       paymentReference,
     });
-    const totalSeats = await sumTeamCoursePurchaseSeats(team.id);
-    await prisma.lmsTeam.update({
-      where: { id: team.id },
-      data: {
-        seatLimit: totalSeats > 0 ? totalSeats : seatCount,
-        bundleTier: COURSE_BUNDLE_TIER,
-      },
-    });
-    await writeTeamCourseSlug(team.id, courseSlug);
+
     return { teamId: team.id, teamSlug: team.slug };
-  }
-
-  const name = 'My team';
-  const slug = await createUniqueTeamSlug(name);
-
-  const team = await prisma.lmsTeam.create({
-    data: {
-      name,
-      slug,
-      ownerId,
-      bundleTier: COURSE_BUNDLE_TIER,
-      seatLimit: seatCount,
-      members: {
-        create: { userId: ownerId, role: 'owner' },
-      },
-    },
-    select: { id: true, slug: true },
   });
-
-  await writeTeamCourseSlug(team.id, courseSlug);
-  await addTeamCoursePurchase({
-    teamId: team.id,
-    courseSlug,
-    seatLimit: seatCount,
-    paymentReference,
-  });
-
-  return { teamId: team.id, teamSlug: team.slug };
 }
 
 export async function fulfillCourseCheckoutForUser(params: {

--- a/src/lib/server/team-course-seats.ts
+++ b/src/lib/server/team-course-seats.ts
@@ -76,10 +76,15 @@ export async function getTeamCoursePurchases(teamId: string): Promise<TeamCourse
     courses.map((c) => [c.slug.trim().toLowerCase(), c.title]),
   );
 
+  const seatsUsedBySlug = new Map<string, number>();
   const rows: TeamCoursePurchaseRow[] = [];
   for (const p of purchases) {
     const slug = p.courseSlug.trim().toLowerCase();
-    const seatsUsed = await countSeatsUsedForTeamCourse(teamId, slug);
+    let seatsUsed = seatsUsedBySlug.get(slug);
+    if (seatsUsed === undefined) {
+      seatsUsed = await countSeatsUsedForTeamCourse(teamId, slug);
+      seatsUsedBySlug.set(slug, seatsUsed);
+    }
     rows.push({
       id: p.id,
       course_slug: slug,

--- a/src/lib/server/team-course-seats.ts
+++ b/src/lib/server/team-course-seats.ts
@@ -1,0 +1,161 @@
+import { prisma } from '@/lib/prisma';
+import {
+  findTeamCoursePurchaseByPaymentReference,
+  findTeamCoursePurchasesByTeamId,
+  insertTeamCoursePurchase,
+} from '@/lib/server/team-course-purchase-db';
+import { readTeamCourseSlug } from '@/lib/server/team-course-slug-db';
+
+export type TeamCoursePurchaseRow = {
+  id: string;
+  course_slug: string;
+  course_title: string;
+  seat_limit: number;
+  seats_used: number;
+  seats_remaining: number;
+  purchased_at: string;
+};
+
+/** Team members with an active enrolment in this course (includes owner). */
+export async function countSeatsUsedForTeamCourse(
+  teamId: string,
+  courseSlug: string,
+): Promise<number> {
+  const slug = courseSlug.trim().toLowerCase();
+  const members = await prisma.lmsTeamMember.findMany({
+    where: { teamId },
+    select: { userId: true },
+  });
+  if (members.length === 0) return 0;
+
+  const userIds = members.map((m) => m.userId);
+  const course = await prisma.lmsCourse.findUnique({
+    where: { slug },
+    select: { id: true },
+  });
+  if (!course) return 0;
+
+  return prisma.lmsEnrollment.count({
+    where: {
+      studentId: { in: userIds },
+      courseId: course.id,
+      status: { notIn: ['cancelled'] },
+    },
+  });
+}
+
+export async function getTeamCoursePurchases(teamId: string): Promise<TeamCoursePurchaseRow[]> {
+  let purchases = await findTeamCoursePurchasesByTeamId(teamId);
+
+  if (purchases.length === 0) {
+    const legacySlug = await readTeamCourseSlug(teamId);
+    const team = await prisma.lmsTeam.findUnique({
+      where: { id: teamId },
+      select: { seatLimit: true, createdAt: true },
+    });
+    if (legacySlug && team) {
+      purchases = [
+        {
+          id: `legacy-${teamId}`,
+          teamId,
+          courseSlug: legacySlug,
+          seatLimit: team.seatLimit,
+          paymentReference: null,
+          purchasedAt: team.createdAt,
+        },
+      ];
+    }
+  }
+
+  const slugs = [...new Set(purchases.map((p) => p.courseSlug.trim().toLowerCase()))];
+  const courses = await prisma.lmsCourse.findMany({
+    where: { slug: { in: slugs } },
+    select: { slug: true, title: true },
+  });
+  const titleBySlug = new Map(
+    courses.map((c) => [c.slug.trim().toLowerCase(), c.title]),
+  );
+
+  const rows: TeamCoursePurchaseRow[] = [];
+  for (const p of purchases) {
+    const slug = p.courseSlug.trim().toLowerCase();
+    const seatsUsed = await countSeatsUsedForTeamCourse(teamId, slug);
+    rows.push({
+      id: p.id,
+      course_slug: slug,
+      course_title: titleBySlug.get(slug) ?? slug.replace(/-/g, ' '),
+      seat_limit: p.seatLimit,
+      seats_used: seatsUsed,
+      seats_remaining: Math.max(0, p.seatLimit - seatsUsed),
+      purchased_at: p.purchasedAt.toISOString(),
+    });
+  }
+
+  return rows;
+}
+
+/** Aggregated seat pools by course (multiple purchases of same course sum seats). */
+export async function getTeamCourseSeatPools(teamId: string) {
+  const purchases = await getTeamCoursePurchases(teamId);
+  const bySlug = new Map<
+    string,
+    TeamCoursePurchaseRow & { purchase_count: number; purchases: TeamCoursePurchaseRow[] }
+  >();
+
+  for (const p of purchases) {
+    const existing = bySlug.get(p.course_slug);
+    if (!existing) {
+      bySlug.set(p.course_slug, {
+        ...p,
+        purchase_count: 1,
+        purchases: [p],
+      });
+    } else {
+      const seatLimit = existing.seat_limit + p.seat_limit;
+      const seatsUsed = Math.max(existing.seats_used, p.seats_used);
+      bySlug.set(p.course_slug, {
+        ...existing,
+        seat_limit: seatLimit,
+        seats_used: seatsUsed,
+        seats_remaining: Math.max(0, seatLimit - seatsUsed),
+        purchase_count: existing.purchase_count + 1,
+        purchases: [...existing.purchases, p],
+      });
+    }
+  }
+
+  return [...bySlug.values()];
+}
+
+export async function addTeamCoursePurchase(params: {
+  teamId: string;
+  courseSlug: string;
+  seatLimit: number;
+  paymentReference?: string;
+}): Promise<void> {
+  const ref = params.paymentReference?.trim();
+  if (ref) {
+    const existing = await findTeamCoursePurchaseByPaymentReference(ref);
+    if (existing) return;
+  }
+
+  await insertTeamCoursePurchase(params);
+}
+
+export async function assertCourseSeatsAvailable(
+  teamId: string,
+  courseSlugs: string[],
+): Promise<void> {
+  const pools = await getTeamCourseSeatPools(teamId);
+  const poolBySlug = new Map(pools.map((p) => [p.course_slug, p]));
+
+  for (const slug of courseSlugs) {
+    const pool = poolBySlug.get(slug);
+    if (!pool) {
+      throw new Error('NO_SEATS_FOR_COURSE');
+    }
+    if (pool.seats_remaining <= 0) {
+      throw new Error('COURSE_SEATS_FULL');
+    }
+  }
+}

--- a/src/lib/server/team-course-slug-db.ts
+++ b/src/lib/server/team-course-slug-db.ts
@@ -1,0 +1,30 @@
+import { prisma } from '@/lib/prisma';
+
+/** Write course_slug even when Prisma Client was generated before the column existed. */
+export async function writeTeamCourseSlug(teamId: string, courseSlug: string): Promise<void> {
+  const slug = courseSlug.trim().toLowerCase();
+  try {
+    await prisma.lmsTeam.update({
+      where: { id: teamId },
+      data: { courseSlug: slug },
+    });
+  } catch {
+    await prisma.$executeRaw`
+      UPDATE lms_teams SET course_slug = ${slug} WHERE id = ${teamId}::uuid
+    `;
+  }
+}
+
+export async function readTeamCourseSlug(teamId: string): Promise<string | null> {
+  const team = await prisma.lmsTeam.findUnique({
+    where: { id: teamId },
+    select: { courseSlug: true },
+  });
+  if (team?.courseSlug?.trim()) return team.courseSlug.trim().toLowerCase();
+
+  const rows = await prisma.$queryRaw<{ course_slug: string | null }[]>`
+    SELECT course_slug FROM lms_teams WHERE id = ${teamId}::uuid
+  `;
+  const raw = rows[0]?.course_slug?.trim().toLowerCase();
+  return raw || null;
+}

--- a/src/lib/server/team-course-slug-db.ts
+++ b/src/lib/server/team-course-slug-db.ts
@@ -16,11 +16,15 @@ export async function writeTeamCourseSlug(teamId: string, courseSlug: string): P
 }
 
 export async function readTeamCourseSlug(teamId: string): Promise<string | null> {
-  const team = await prisma.lmsTeam.findUnique({
-    where: { id: teamId },
-    select: { courseSlug: true },
-  });
-  if (team?.courseSlug?.trim()) return team.courseSlug.trim().toLowerCase();
+  try {
+    const team = await prisma.lmsTeam.findUnique({
+      where: { id: teamId },
+      select: { courseSlug: true },
+    });
+    if (team?.courseSlug?.trim()) return team.courseSlug.trim().toLowerCase();
+  } catch {
+    // Stale Prisma client may lack courseSlug; fall back to raw SQL below.
+  }
 
   const rows = await prisma.$queryRaw<{ course_slug: string | null }[]>`
     SELECT course_slug FROM lms_teams WHERE id = ${teamId}::uuid

--- a/src/lib/server/team-member-provision.ts
+++ b/src/lib/server/team-member-provision.ts
@@ -1,0 +1,152 @@
+import { randomUUID } from 'node:crypto';
+
+import { prisma } from '@/lib/prisma';
+import { enrollStudentInCourse } from '@/lib/server/enrollment-service';
+import { hashPassword, sessionClaimsForUserId } from '@/lib/server/lms-auth';
+import { generateMemberTempPassword } from '@/lib/server/member-temp-password';
+import { sendTeamMemberAddedEmail } from '@/lib/server/transactional-email';
+import { assertCourseSeatsAvailable } from '@/lib/server/team-course-seats';
+import { listTeamCoursePurchaseSlugs } from '@/lib/server/team-course-purchase-db';
+import { readTeamCourseSlug } from '@/lib/server/team-course-slug-db';
+import { repairAndGetTeamForUser } from '@/lib/server/teams';
+
+/**
+ * Add a team member by email and grant access only to the selected courses.
+ * Each person gets their own unique sign-in password in the email.
+ */
+export async function addCourseTeamMemberByEmail(params: {
+  ownerId: string;
+  inviterName: string;
+  email: string;
+  appOrigin: string;
+  courseSlugs: string[];
+}): Promise<{ email: string; account_created: boolean; courses: string[] }> {
+  const email = params.email.trim().toLowerCase();
+  if (!email.includes('@')) {
+    throw new Error('INVALID_EMAIL');
+  }
+
+  const slugs = [
+    ...new Set(
+      params.courseSlugs.map((s) => s.trim().toLowerCase()).filter((s) => s.length > 0),
+    ),
+  ];
+  if (slugs.length === 0) {
+    throw new Error('NO_COURSES_SELECTED');
+  }
+
+  const team = await repairAndGetTeamForUser(params.ownerId);
+  if (!team || team.ownerId !== params.ownerId) {
+    throw new Error('NO_TEAM');
+  }
+
+  const membership = team.members.find((m) => m.userId === params.ownerId);
+  if (!membership || !['owner', 'admin'].includes(membership.role)) {
+    throw new Error('FORBIDDEN');
+  }
+
+  const ownerEnrollments = await prisma.lmsEnrollment.findMany({
+    where: {
+      studentId: params.ownerId,
+      status: { notIn: ['cancelled'] },
+      course: { slug: { in: slugs } },
+    },
+    include: { course: { select: { slug: true, title: true } } },
+  });
+
+  const allowedSlugs = new Set(
+    ownerEnrollments.map((e) => e.course.slug.trim().toLowerCase()),
+  );
+  const invalid = slugs.filter((s) => !allowedSlugs.has(s));
+  if (invalid.length > 0) {
+    throw new Error('OWNER_NOT_ENROLLED');
+  }
+
+  const teamPurchaseSlugs = new Set(await listTeamCoursePurchaseSlugs(team.id));
+  const legacySlug =
+    team.courseSlug?.trim().toLowerCase() ?? (await readTeamCourseSlug(team.id));
+  if (legacySlug) teamPurchaseSlugs.add(legacySlug);
+
+  const teamCourseSlugs = slugs.filter((s) => teamPurchaseSlugs.has(s));
+  if (teamCourseSlugs.length > 0) {
+    try {
+      await assertCourseSeatsAvailable(team.id, teamCourseSlugs);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (msg === 'COURSE_SEATS_FULL') throw new Error('COURSE_SEATS_FULL');
+      if (msg === 'NO_SEATS_FOR_COURSE') throw new Error('NO_SEATS_FOR_COURSE');
+      throw e;
+    }
+  }
+
+  const courseTitles = ownerEnrollments
+    .filter((e) => slugs.includes(e.course.slug.trim().toLowerCase()))
+    .map((e) => e.course.title);
+
+  const existingOnTeam = team.members.find((m) => m.user.email.toLowerCase() === email);
+  if (existingOnTeam) {
+    throw new Error('ALREADY_MEMBER');
+  }
+
+  let user = await prisma.lmsUser.findUnique({ where: { email } });
+  let accountCreated = false;
+
+  const memberPassword = generateMemberTempPassword();
+  const hashedPassword = await hashPassword(memberPassword);
+
+  if (!user) {
+    const id = randomUUID();
+    user = await prisma.lmsUser.create({
+      data: {
+        id,
+        email,
+        hashedPassword,
+        fullName: email.split('@')[0],
+        isActive: true,
+        isVerified: false,
+      },
+    });
+    accountCreated = true;
+  } else {
+    await prisma.lmsUser.update({
+      where: { id: user.id },
+      data: { hashedPassword },
+    });
+  }
+
+  await prisma.lmsTeamMember.upsert({
+    where: { teamId_userId: { teamId: team.id, userId: user.id } },
+    create: { teamId: team.id, userId: user.id, role: 'member' },
+    update: {},
+  });
+
+  const memberClaims = await sessionClaimsForUserId(user.id);
+  if (!memberClaims) {
+    throw new Error('USER_INACTIVE');
+  }
+
+  for (const slug of slugs) {
+    try {
+      await enrollStudentInCourse(memberClaims, slug, `team:${team.id}`);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (msg !== 'COURSE_NOT_FOUND') {
+        console.error('[team-member-provision] enrol', slug, e);
+      }
+    }
+  }
+
+  const memberName = user.fullName?.trim() || email.split('@')[0] || 'there';
+
+  void sendTeamMemberAddedEmail({
+    to: email,
+    memberName,
+    inviterName: params.inviterName,
+    teamName: team.name,
+    courseTitles,
+    appOrigin: params.appOrigin,
+    temporaryPassword: memberPassword,
+  }).catch((e) => console.error('[team-member-provision] email', e));
+
+  return { email, account_created: accountCreated, courses: courseTitles };
+}

--- a/src/lib/server/team-member-provision.ts
+++ b/src/lib/server/team-member-provision.ts
@@ -67,20 +67,31 @@ export async function addCourseTeamMemberByEmail(params: {
     team.courseSlug?.trim().toLowerCase() ?? (await readTeamCourseSlug(team.id));
   if (legacySlug) teamPurchaseSlugs.add(legacySlug);
 
+  const isCoursePurchaseTeam =
+    team.bundleTier === 'course_purchase' && teamPurchaseSlugs.size > 0;
   const teamCourseSlugs = slugs.filter((s) => teamPurchaseSlugs.has(s));
-  if (teamCourseSlugs.length > 0) {
-    try {
-      await assertCourseSeatsAvailable(team.id, teamCourseSlugs);
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      if (msg === 'COURSE_SEATS_FULL') throw new Error('COURSE_SEATS_FULL');
-      if (msg === 'NO_SEATS_FOR_COURSE') throw new Error('NO_SEATS_FOR_COURSE');
-      throw e;
+
+  if (isCoursePurchaseTeam) {
+    const notInPool = slugs.filter((s) => !teamPurchaseSlugs.has(s));
+    if (notInPool.length > 0) {
+      throw new Error('NOT_TEAM_PURCHASE_COURSE');
+    }
+    if (teamCourseSlugs.length > 0) {
+      try {
+        await assertCourseSeatsAvailable(team.id, teamCourseSlugs);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        if (msg === 'COURSE_SEATS_FULL') throw new Error('COURSE_SEATS_FULL');
+        if (msg === 'NO_SEATS_FOR_COURSE') throw new Error('NO_SEATS_FOR_COURSE');
+        throw e;
+      }
     }
   }
 
+  const enrollSlugs = isCoursePurchaseTeam ? teamCourseSlugs : slugs;
+
   const courseTitles = ownerEnrollments
-    .filter((e) => slugs.includes(e.course.slug.trim().toLowerCase()))
+    .filter((e) => enrollSlugs.includes(e.course.slug.trim().toLowerCase()))
     .map((e) => e.course.title);
 
   const existingOnTeam = team.members.find((m) => m.user.email.toLowerCase() === email);
@@ -120,7 +131,7 @@ export async function addCourseTeamMemberByEmail(params: {
     throw new Error('USER_INACTIVE');
   }
 
-  for (const slug of slugs) {
+  for (const slug of enrollSlugs) {
     try {
       await enrollStudentInCourse(memberClaims, slug, `team:${team.id}`);
     } catch (e) {

--- a/src/lib/server/team-member-provision.ts
+++ b/src/lib/server/team-member-provision.ts
@@ -90,11 +90,11 @@ export async function addCourseTeamMemberByEmail(params: {
 
   let user = await prisma.lmsUser.findUnique({ where: { email } });
   let accountCreated = false;
-
-  const memberPassword = generateMemberTempPassword();
-  const hashedPassword = await hashPassword(memberPassword);
+  let memberPassword: string | null = null;
 
   if (!user) {
+    memberPassword = generateMemberTempPassword();
+    const hashedPassword = await hashPassword(memberPassword);
     const id = randomUUID();
     user = await prisma.lmsUser.create({
       data: {
@@ -107,11 +107,6 @@ export async function addCourseTeamMemberByEmail(params: {
       },
     });
     accountCreated = true;
-  } else {
-    await prisma.lmsUser.update({
-      where: { id: user.id },
-      data: { hashedPassword },
-    });
   }
 
   await prisma.lmsTeamMember.upsert({
@@ -145,7 +140,7 @@ export async function addCourseTeamMemberByEmail(params: {
     teamName: team.name,
     courseTitles,
     appOrigin: params.appOrigin,
-    temporaryPassword: memberPassword,
+    ...(memberPassword ? { temporaryPassword: memberPassword } : {}),
   }).catch((e) => console.error('[team-member-provision] email', e));
 
   return { email, account_created: accountCreated, courses: courseTitles };

--- a/src/lib/server/teams.ts
+++ b/src/lib/server/teams.ts
@@ -56,24 +56,47 @@ export async function countTeamSeatsUsed(teamId: string): Promise<number> {
   return prisma.lmsTeamMember.count({ where: { teamId } });
 }
 
+const teamInclude = {
+  members: {
+    include: {
+      user: { select: { id: true, email: true, fullName: true } },
+    },
+  },
+  invites: {
+    where: { acceptedAt: null, expiresAt: { gt: new Date() } },
+    orderBy: { createdAt: 'desc' as const },
+  },
+};
+
 export async function getTeamForUser(userId: string) {
   const membership = await prisma.lmsTeamMember.findFirst({
     where: { userId },
     include: {
       team: {
-        include: {
-          members: {
-            include: {
-              user: { select: { id: true, email: true, fullName: true } },
-            },
-          },
-          invites: {
-            where: { acceptedAt: null, expiresAt: { gt: new Date() } },
-            orderBy: { createdAt: 'desc' },
-          },
-        },
+        include: teamInclude,
       },
     },
   });
   return membership?.team ?? null;
+}
+
+/** Membership row missing after checkout — attach owner to their course-purchase team. */
+export async function repairAndGetTeamForUser(userId: string) {
+  const direct = await getTeamForUser(userId);
+  if (direct) return direct;
+
+  const ownedCourseTeam = await prisma.lmsTeam.findFirst({
+    where: { ownerId: userId, bundleTier: 'course_purchase' },
+  });
+  if (!ownedCourseTeam) return null;
+
+  await prisma.lmsTeamMember.upsert({
+    where: {
+      teamId_userId: { teamId: ownedCourseTeam.id, userId },
+    },
+    create: { teamId: ownedCourseTeam.id, userId, role: 'owner' },
+    update: { role: 'owner' },
+  });
+
+  return getTeamForUser(userId);
 }

--- a/src/lib/server/teams.ts
+++ b/src/lib/server/teams.ts
@@ -56,24 +56,26 @@ export async function countTeamSeatsUsed(teamId: string): Promise<number> {
   return prisma.lmsTeamMember.count({ where: { teamId } });
 }
 
-const teamInclude = {
-  members: {
-    include: {
-      user: { select: { id: true, email: true, fullName: true } },
+function teamInclude() {
+  return {
+    members: {
+      include: {
+        user: { select: { id: true, email: true, fullName: true } },
+      },
     },
-  },
-  invites: {
-    where: { acceptedAt: null, expiresAt: { gt: new Date() } },
-    orderBy: { createdAt: 'desc' as const },
-  },
-};
+    invites: {
+      where: { acceptedAt: null, expiresAt: { gt: new Date() } },
+      orderBy: { createdAt: 'desc' as const },
+    },
+  };
+}
 
 export async function getTeamForUser(userId: string) {
   const membership = await prisma.lmsTeamMember.findFirst({
     where: { userId },
     include: {
       team: {
-        include: teamInclude,
+        include: teamInclude(),
       },
     },
   });

--- a/src/lib/server/transactional-email.ts
+++ b/src/lib/server/transactional-email.ts
@@ -107,7 +107,7 @@ export async function sendTeamMemberAddedEmail(params: {
   teamName: string;
   courseTitles: string[];
   appOrigin: string;
-  temporaryPassword: string;
+  temporaryPassword?: string;
 }): Promise<SendEmailResult> {
   const base = params.appOrigin.replace(/\/$/, '');
   const loginUrl = `${base}/login`;
@@ -115,7 +115,9 @@ export async function sendTeamMemberAddedEmail(params: {
   const subjectCourse =
     params.courseTitles.length === 1
       ? params.courseTitles[0]!
-      : `${params.courseTitles.length} CARSI courses`;
+      : params.courseTitles.length > 1
+        ? `${params.courseTitles.length} CARSI courses`
+        : 'your CARSI courses';
 
   const { html, text } = renderTeamMemberAddedEmail({
     appOrigin: base,

--- a/src/lib/server/transactional-email.ts
+++ b/src/lib/server/transactional-email.ts
@@ -9,6 +9,7 @@ import {
   renderEnrollmentWelcomeEmail,
   renderPasswordResetEmail,
   renderRegistrationWelcomeEmail,
+  renderTeamMemberAddedEmail,
 } from '@/lib/server/email-templates';
 import { sendEmail, isEmailConfigured, type SendEmailResult } from '@/lib/server/email';
 import { getFirstLessonLearnPath } from '@/lib/server/first-lesson';
@@ -94,6 +95,42 @@ export async function sendEnrollmentWelcomeEmail(params: {
   return sendEmail({
     to: user.email,
     subject: `You're enrolled — ${course.title}`,
+    html,
+    text,
+  });
+}
+
+export async function sendTeamMemberAddedEmail(params: {
+  to: string;
+  memberName: string;
+  inviterName: string;
+  teamName: string;
+  courseTitles: string[];
+  appOrigin: string;
+  temporaryPassword: string;
+}): Promise<SendEmailResult> {
+  const base = params.appOrigin.replace(/\/$/, '');
+  const loginUrl = `${base}/login`;
+  const name = params.memberName.trim() || params.to.split('@')[0];
+  const subjectCourse =
+    params.courseTitles.length === 1
+      ? params.courseTitles[0]!
+      : `${params.courseTitles.length} CARSI courses`;
+
+  const { html, text } = renderTeamMemberAddedEmail({
+    appOrigin: base,
+    memberName: name,
+    inviterName: params.inviterName,
+    teamName: params.teamName,
+    courseTitles: params.courseTitles,
+    loginUrl,
+    memberEmail: params.to,
+    temporaryPassword: params.temporaryPassword,
+  });
+
+  return sendEmail({
+    to: params.to,
+    subject: `${params.inviterName} gave you access to ${subjectCourse}`,
     html,
     text,
   });

--- a/src/lib/wordpress-export-courses.ts
+++ b/src/lib/wordpress-export-courses.ts
@@ -2,6 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { getLmsSeedExportRows } from '@/lib/lms-seed-catalog';
+import { formatCecHoursForDisplay } from '@/lib/cec-display';
+import { enrichCourseWithCecHours, resolveCecHours } from '@/lib/seed/cec-hours';
 import { normalizePublicAssetUrl } from '@/lib/remote-image';
 
 /** U+2028/U+2029 break JS string embedding in some bundlers; strip from user-facing text. */
@@ -31,6 +33,7 @@ export interface WpExportCourse {
   price_aud: number;
   is_free?: boolean;
   iicrc_discipline?: string | null;
+  cec_hours?: number | null;
   status?: string;
   wp_id: number;
   level?: string | null;
@@ -123,6 +126,13 @@ export type CourseListItem = {
 };
 
 export function mapWpExportToCourseListItem(row: WpExportCourse): CourseListItem {
+  const cec = resolveCecHours({
+    cec_hours: row.cec_hours,
+    short_description: row.short_description,
+    description: row.description,
+    meta: row.meta,
+  });
+
   return {
     id: String(row.wp_id),
     slug: row.slug,
@@ -138,7 +148,7 @@ export function mapWpExportToCourseListItem(row: WpExportCourse): CourseListItem
     lesson_count: row.lesson_count ?? null,
     updated_at: null,
     instructor: null,
-    cec_hours: null,
+    cec_hours: formatCecHoursForDisplay(cec),
     duration_hours: null,
   };
 }
@@ -153,7 +163,7 @@ export function loadWpExportCourses(): WpExportCourse[] | null {
     const raw = fs.readFileSync(WP_EXPORT_COURSES_PATH, 'utf-8');
     const parsed = JSON.parse(raw) as unknown;
     if (!Array.isArray(parsed) || parsed.length === 0) return null;
-    return parsed as WpExportCourse[];
+    return (parsed as WpExportCourse[]).map((c) => enrichCourseWithCecHours(c));
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
<!-- 1-3 sentences: what changed and why -->

## Registry impact
- [ ] No registry change required
- [ ] Updated `.portfolio/PORTFOLIO.yaml` (only Unite-Hub holds the registry)
- [ ] N/A — this repo is not Unite-Hub (no registry here)

## Sandbox testing
- [ ] Tested on sandbox deployment (URL: ____________)
- [ ] N/A — not user-facing / config change only

## Verification
- [ ] Type checks pass (`npm run typecheck` or equivalent)
- [ ] Tests pass (or none applicable)
- [ ] Build succeeds (`npm run build`)
- [ ] Manual smoke test of changed feature

## Screenshots / recordings
<!-- For UI changes -->

## Rollback plan
<!-- How to revert if this breaks prod -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team purchases: multi-seat checkout, team dashboard flow, invite & seat management, and team activation
  * Bulk admin actions: enroll multiple courses and bulk-mark completions; admin multi-select UI
  * Course UI: CEC hours badges on cards/thumbnails; course-level purchase options (team vs self)

* **Improvements**
  * Safer post-login redirects and login redirect support
  * Consistent CEC-hour resolution and seeding across sources
  * Homepage and dashboard UI robustness and routing refinements (student → dashboard/student)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CleanExpo/CARSI/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->