### PR TITLE
fix(lms): dedupe Stripe webhook events

### DIFF
--- a/app/api/lms/webhooks/stripe/route.ts
+++ b/app/api/lms/webhooks/stripe/route.ts
@@ -14,7 +14,18 @@ import { sendEnrollmentWelcomeEmail } from '@/lib/server/enrollment-email';
 import { ensureGuestUserFromStripeEmail } from '@/lib/server/guest-checkout';
 import { sessionClaimsForUserId } from '@/lib/server/lms-auth';
 import { prisma } from '@/lib/prisma';
+import {
+  claimStripeWebhookEvent,
+  markStripeWebhookEventProcessed,
+  releaseStripeWebhookEventClaim,
+} from '@/lib/server/stripe-webhook-idempotency';
 import { fulfillCourseCheckoutForUser } from '@/lib/server/team-course-purchase';
+
+type StripeWebhookEventDelegate = {
+  create(args: { data: { id: string; type: string } }): Promise<unknown>;
+  update(args: { where: { id: string }; data: { processedAt: Date } }): Promise<unknown>;
+  delete(args: { where: { id: string } }): Promise<unknown>;
+};
 
 export async function POST(request: NextRequest) {
   const rawBody = await request.text();
@@ -35,52 +46,67 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
   }
 
-  if (event.type !== 'checkout.session.completed') {
-    return NextResponse.json({ received: true });
-  }
-
-  const session = event.data.object as Stripe.Checkout.Session;
-
-  if (session.payment_status && session.payment_status !== 'paid') {
-    return NextResponse.json({ received: true });
-  }
-
-  const slug = session.metadata?.course_slug?.trim().toLowerCase();
-  if (!slug) {
-    return NextResponse.json({ received: true });
-  }
-
   if (!process.env.DATABASE_URL?.trim()) {
     return NextResponse.json({ error: 'Database not configured' }, { status: 503 });
   }
 
-  const studentIdMeta = session.metadata?.student_id?.trim();
-  const email =
-    (session.customer_email ?? session.customer_details?.email)?.trim().toLowerCase() ?? '';
-
-  let claims = studentIdMeta ? await sessionClaimsForUserId(studentIdMeta) : null;
-  if (!claims && email) {
-    const user = await prisma.lmsUser.findUnique({ where: { email } });
-    if (user) claims = await sessionClaimsForUserId(user.id);
-  }
-  if (!claims && email && session.metadata?.guest_checkout === 'true') {
-    claims = await ensureGuestUserFromStripeEmail(email);
-  }
-
-  if (!claims) {
-    console.warn('[stripe webhook] checkout.session.completed: could not resolve learner', {
-      slug,
-      hasStudentMeta: Boolean(studentIdMeta),
-      hasEmail: Boolean(email),
+  const stripeWebhookEvents = (prisma as unknown as { stripeWebhookEvent: StripeWebhookEventDelegate })
+    .stripeWebhookEvent;
+  const claim = await claimStripeWebhookEvent(stripeWebhookEvents, event);
+  if (!claim.claimed) {
+    console.warn('[stripe webhook] duplicate event, skipped', {
+      id: event.id,
+      type: event.type,
     });
-    return NextResponse.json({ received: true });
+    return NextResponse.json({ received: true, status: 'duplicate' });
   }
 
-  const purchaseMode = session.metadata?.purchase_mode === 'team' ? 'team' : 'self';
-  const teamSeatRaw = session.metadata?.team_seat_count;
-  const teamSeatCount = teamSeatRaw ? Number.parseInt(teamSeatRaw, 10) : undefined;
+  const acknowledge = async () => {
+    await markStripeWebhookEventProcessed(stripeWebhookEvents, event.id);
+    return NextResponse.json({ received: true });
+  };
 
   try {
+    if (event.type !== 'checkout.session.completed') {
+      return acknowledge();
+    }
+
+    const session = event.data.object as Stripe.Checkout.Session;
+
+    if (session.payment_status && session.payment_status !== 'paid') {
+      return acknowledge();
+    }
+
+    const slug = session.metadata?.course_slug?.trim().toLowerCase();
+    if (!slug) {
+      return acknowledge();
+    }
+
+    const studentIdMeta = session.metadata?.student_id?.trim();
+    const email =
+      (session.customer_email ?? session.customer_details?.email)?.trim().toLowerCase() ?? '';
+
+    let claims = studentIdMeta ? await sessionClaimsForUserId(studentIdMeta) : null;
+    if (!claims && email) {
+      const user = await prisma.lmsUser.findUnique({ where: { email } });
+      if (user) claims = await sessionClaimsForUserId(user.id);
+    }
+    if (!claims && email && session.metadata?.guest_checkout === 'true') {
+      claims = await ensureGuestUserFromStripeEmail(email);
+    }
+
+    if (!claims) {
+      console.warn('[stripe webhook] checkout.session.completed: could not resolve learner', {
+        slug,
+        hasStudentMeta: Boolean(studentIdMeta),
+        hasEmail: Boolean(email),
+      });
+      return acknowledge();
+    }
+
+    const purchaseMode = session.metadata?.purchase_mode === 'team' ? 'team' : 'self';
+    const teamSeatRaw = session.metadata?.team_seat_count;
+    const teamSeatCount = teamSeatRaw ? Number.parseInt(teamSeatRaw, 10) : undefined;
     const ref = typeof session.id === 'string' ? session.id : 'stripe_webhook';
     const origin = getAppOrigin();
     const fulfilled = await fulfillCourseCheckoutForUser({
@@ -109,8 +135,10 @@ export async function POST(request: NextRequest) {
       console.warn('[stripe webhook] team purchase blocked: user on another team');
     } else {
       console.error('[stripe webhook] enrolment error:', e);
+      await releaseStripeWebhookEventClaim(stripeWebhookEvents, event.id);
+      return NextResponse.json({ error: 'Stripe webhook processing failed' }, { status: 500 });
     }
   }
 
-  return NextResponse.json({ received: true });
+  return acknowledge();
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "db:seed-odour-smoke-psychro-drying-docx": "npx tsx scripts/seed-odour-smoke-psychro-drying-docx.ts",
     "lint": "eslint .",
     "type-check": "tsc --noEmit",
+    "test:stripe-webhook": "node scripts/test-stripe-webhook-idempotency.mjs",
     "db:seed-phase2": "npx tsx scripts/seed-phase2-pathways-quizzes.ts",
     "test:a11y": "playwright test tests/accessibility",
     "test:e2e": "playwright test",

--- a/prisma/migrations/20260530000000_stripe_webhook_events/migration.sql
+++ b/prisma/migrations/20260530000000_stripe_webhook_events/migration.sql
@@ -1,0 +1,11 @@
+-- Stripe webhook event-id guard. Stripe delivers events at least once; this
+-- table lets the LMS webhook skip replayed events before enrollment side
+-- effects run a second time.
+CREATE TABLE IF NOT EXISTS "stripe_webhook_events" (
+    "id" TEXT NOT NULL,
+    "type" VARCHAR(128) NOT NULL,
+    "processed_at" TIMESTAMPTZ(6),
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "stripe_webhook_events_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -385,6 +385,17 @@ model CrmEventLog {
   @@map("crm_event_logs")
 }
 
+/// Stripe webhook idempotency guard. Stripe delivers webhooks at least once,
+/// so handlers must claim event IDs before side effects and skip replays.
+model StripeWebhookEvent {
+  id          String    @id
+  type        String    @db.VarChar(128)
+  processedAt DateTime? @map("processed_at") @db.Timestamptz(6)
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  @@map("stripe_webhook_events")
+}
+
 model AdminUser {
   id             String    @id @default(uuid()) @db.Uuid
   email          String    @unique

--- a/scripts/test-stripe-webhook-idempotency.mjs
+++ b/scripts/test-stripe-webhook-idempotency.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  claimStripeWebhookEvent,
+  markStripeWebhookEventProcessed,
+  releaseStripeWebhookEventClaim,
+} from '../src/lib/server/stripe-webhook-idempotency.js';
+
+function duplicateError() {
+  return Object.assign(new Error('duplicate'), { code: 'P2002' });
+}
+
+function notFoundError() {
+  return Object.assign(new Error('not found'), { code: 'P2025' });
+}
+
+test('claimStripeWebhookEvent creates a first-time event row', async () => {
+  const calls = [];
+  const delegate = {
+    async create(args) {
+      calls.push(args);
+    },
+  };
+
+  const result = await claimStripeWebhookEvent(delegate, {
+    id: 'evt_123',
+    type: 'checkout.session.completed',
+  });
+
+  assert.deepEqual(result, { claimed: true });
+  assert.deepEqual(calls, [
+    {
+      data: {
+        id: 'evt_123',
+        type: 'checkout.session.completed',
+      },
+    },
+  ]);
+});
+
+test('claimStripeWebhookEvent reports duplicates without throwing', async () => {
+  const delegate = {
+    async create() {
+      throw duplicateError();
+    },
+  };
+
+  const result = await claimStripeWebhookEvent(delegate, {
+    id: 'evt_123',
+    type: 'checkout.session.completed',
+  });
+
+  assert.deepEqual(result, { claimed: false });
+});
+
+test('markStripeWebhookEventProcessed records the processed timestamp', async () => {
+  const processedAt = new Date('2026-05-30T00:00:00.000Z');
+  const calls = [];
+  const delegate = {
+    async update(args) {
+      calls.push(args);
+    },
+  };
+
+  await markStripeWebhookEventProcessed(delegate, 'evt_123', processedAt);
+
+  assert.deepEqual(calls, [
+    {
+      where: { id: 'evt_123' },
+      data: { processedAt },
+    },
+  ]);
+});
+
+test('releaseStripeWebhookEventClaim deletes the claim and ignores missing rows', async () => {
+  const deleted = [];
+  const delegate = {
+    async delete(args) {
+      deleted.push(args);
+    },
+  };
+
+  await releaseStripeWebhookEventClaim(delegate, 'evt_123');
+  assert.deepEqual(deleted, [{ where: { id: 'evt_123' } }]);
+
+  await releaseStripeWebhookEventClaim(
+    {
+      async delete() {
+        throw notFoundError();
+      },
+    },
+    'evt_missing'
+  );
+});

--- a/src/lib/server/stripe-webhook-idempotency.js
+++ b/src/lib/server/stripe-webhook-idempotency.js
@@ -1,0 +1,39 @@
+function hasPrismaCode(error, code) {
+  return Boolean(error && typeof error === 'object' && error.code === code);
+}
+
+export async function claimStripeWebhookEvent(delegate, event) {
+  if (!event?.id) {
+    throw new Error('Stripe event id is required');
+  }
+
+  try {
+    await delegate.create({
+      data: {
+        id: event.id,
+        type: event.type,
+      },
+    });
+    return { claimed: true };
+  } catch (error) {
+    if (hasPrismaCode(error, 'P2002')) {
+      return { claimed: false };
+    }
+    throw error;
+  }
+}
+
+export async function markStripeWebhookEventProcessed(delegate, eventId, processedAt = new Date()) {
+  await delegate.update({
+    where: { id: eventId },
+    data: { processedAt },
+  });
+}
+
+export async function releaseStripeWebhookEventClaim(delegate, eventId) {
+  try {
+    await delegate.delete({ where: { id: eventId } });
+  } catch (error) {
+    if (!hasPrismaCode(error, 'P2025')) throw error;
+  }
+}


### PR DESCRIPTION
Fixes #136.

What changed:
- add a `stripe_webhook_events` table/model to claim Stripe event IDs before side effects
- return 200 for duplicate events so Stripe replays do not create duplicate enrolments/emails
- release the claim and return 500 on real processing failures so Stripe can retry
- add a small node:test coverage path for claim/process/release behavior

Checked:
- `npm ci`
- `npm run test:stripe-webhook`
- `npm run type-check`
- `npm run lint` (0 errors, existing warnings only)
- `git diff --check`

Note: `npm ci` warns that this repo wants Node 22.x while this machine has Node 24.14.1. I left unrelated audit/dependency warnings untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Stripe webhook processing with idempotency protection to prevent duplicate charges and course enrollments from retried webhook events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CleanExpo/CARSI/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->