### PR TITLE
feat(admin): surface Start Smart lead context

### DIFF
--- a/app/(admin)/admin/contacts/page.tsx
+++ b/app/(admin)/admin/contacts/page.tsx
@@ -10,20 +10,43 @@ type ContactRow = {
   last_name: string;
   email: string;
   message: string;
+  raw_message?: string;
+  lead_context?: {
+    source?: string;
+    topic?: string;
+    pathway?: string;
+    intent?: string;
+    page_url?: string;
+  };
   status: string;
   created_at: string;
 };
+
+const LEAD_FILTERS = [
+  { label: 'All leads', value: '' },
+  { label: 'Course', value: 'course-enquiry' },
+  { label: 'CCW workshop', value: 'ccw-workshop' },
+  { label: 'Equipment/service', value: 'equipment-service-guidance' },
+  { label: 'Team/buyer', value: 'team-or-buyer' },
+] as const;
+
+function formatLeadValue(value?: string) {
+  return value?.replaceAll('-', ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+}
 
 export default function AdminContactsPage() {
   const [items, setItems] = useState<ContactRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [leadIntent, setLeadIntent] = useState('');
 
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch('/api/admin/contacts');
+      const params = new URLSearchParams();
+      if (leadIntent) params.set('lead_intent', leadIntent);
+      const res = await fetch(`/api/admin/contacts${params.toString() ? `?${params}` : ''}`);
       if (!res.ok) throw new Error('Failed to load');
       const data = (await res.json()) as { items: ContactRow[] };
       setItems(data.items ?? []);
@@ -32,7 +55,7 @@ export default function AdminContactsPage() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [leadIntent]);
 
   useEffect(() => {
     void load();
@@ -47,11 +70,31 @@ export default function AdminContactsPage() {
     void load();
   }
 
+  function handleLeadFilter(intent: string) {
+    setLeadIntent(intent);
+  }
+
   return (
     <div className="space-y-6 p-6">
       <div>
         <h1 className="text-2xl font-bold text-white">Contact inbox</h1>
-        <p className="text-sm text-white/50">Messages from the public contact form</p>
+        <p className="text-sm text-white/50">
+          Messages from the public contact form, including Start Smart lead routing context.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {LEAD_FILTERS.map((filter) => (
+          <Button
+            key={filter.value || 'all'}
+            size="sm"
+            variant={leadIntent === filter.value ? 'default' : 'outline'}
+            className={leadIntent === filter.value ? '' : 'border-white/15 text-white/70'}
+            onClick={() => handleLeadFilter(filter.value)}
+          >
+            {filter.label}
+          </Button>
+        ))}
       </div>
 
       {loading ? <p className="text-white/50">Loading…</p> : null}
@@ -79,6 +122,37 @@ export default function AdminContactsPage() {
                 {row.status}
               </span>
             </div>
+            {row.lead_context && Object.keys(row.lead_context).length > 0 ? (
+              <div className="mt-4 rounded-sm border border-[#2490ed]/25 bg-[#2490ed]/10 p-3">
+                <div className="mb-3 flex flex-wrap items-center gap-2">
+                  <span className="rounded-full bg-[#2490ed]/20 px-2 py-0.5 text-[10px] font-semibold tracking-wide text-[#7ec5ff] uppercase">
+                    Start Smart lead
+                  </span>
+                  {row.lead_context.intent ? (
+                    <span className="rounded-full border border-white/10 px-2 py-0.5 text-[10px] text-white/60">
+                      {formatLeadValue(row.lead_context.intent)}
+                    </span>
+                  ) : null}
+                </div>
+                <div className="grid gap-2 md:grid-cols-2 lg:grid-cols-4">
+                  {[
+                    ['Source', formatLeadValue(row.lead_context.source)],
+                    ['Topic', row.lead_context.topic],
+                    ['Pathway', formatLeadValue(row.lead_context.pathway)],
+                    ['Source page', row.lead_context.page_url],
+                  ]
+                    .filter(([, value]) => Boolean(value))
+                    .map(([label, value]) => (
+                      <div key={label} className="rounded-sm bg-white/[0.04] px-3 py-2">
+                        <p className="text-[10px] font-semibold tracking-wide text-white/35 uppercase">
+                          {label}
+                        </p>
+                        <p className="mt-1 break-words text-xs leading-5 text-white/75">{value}</p>
+                      </div>
+                    ))}
+                </div>
+              </div>
+            ) : null}
             <p className="mt-3 text-sm whitespace-pre-wrap text-white/70">{row.message}</p>
             <div className="mt-3 flex flex-wrap gap-2">
               {(['read', 'replied', 'archived'] as const).map((s) => (

--- a/app/api/admin/contacts/route.ts
+++ b/app/api/admin/contacts/route.ts
@@ -3,6 +3,50 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAdminSessionOrNull } from '@/lib/admin/admin-session';
 import { prisma } from '@/lib/prisma';
 
+type LeadContext = {
+  source?: string;
+  topic?: string;
+  pathway?: string;
+  intent?: string;
+  page_url?: string;
+};
+
+const LEAD_PREFIXES = {
+  'Lead source': 'source',
+  'Lead topic': 'topic',
+  'Start Smart pathway': 'pathway',
+  'Lead intent': 'intent',
+  'Source page': 'page_url',
+} as const;
+
+function parseLeadContext(message: string): { leadContext: LeadContext; cleanMessage: string } {
+  const [maybeHeader, ...rest] = message.split(/\n\s*\n/);
+  const leadContext: LeadContext = {};
+  const lines = maybeHeader?.split('\n') ?? [];
+  let matched = 0;
+
+  for (const line of lines) {
+    const [rawKey, ...valueParts] = line.split(':');
+    const key = rawKey?.trim() as keyof typeof LEAD_PREFIXES;
+    const field = LEAD_PREFIXES[key];
+    const value = valueParts.join(':').trim();
+
+    if (field && value) {
+      leadContext[field] = value;
+      matched += 1;
+    }
+  }
+
+  if (!matched) {
+    return { leadContext, cleanMessage: message };
+  }
+
+  return {
+    leadContext,
+    cleanMessage: rest.join('\n\n').trim() || message,
+  };
+}
+
 /** GET /api/admin/contacts — list contact submissions (newest first). */
 export async function GET(request: NextRequest) {
   const session = await getAdminSessionOrNull();
@@ -15,25 +59,35 @@ export async function GET(request: NextRequest) {
   }
 
   const status = request.nextUrl.searchParams.get('status')?.trim();
+  const leadIntent = request.nextUrl.searchParams.get('lead_intent')?.trim();
   const limit = Math.min(Number(request.nextUrl.searchParams.get('limit') ?? 50), 100);
 
   const items = await prisma.contactSubmission.findMany({
-    where: status ? { status } : undefined,
+    where: {
+      ...(status ? { status } : {}),
+      ...(leadIntent ? { message: { contains: `Lead intent: ${leadIntent}` } } : {}),
+    },
     orderBy: { createdAt: 'desc' },
     take: limit,
   });
 
   return NextResponse.json({
-    items: items.map((r) => ({
-      id: r.id,
-      first_name: r.firstName,
-      last_name: r.lastName,
-      email: r.email,
-      message: r.message,
-      status: r.status,
-      source_ip: r.sourceIp,
-      created_at: r.createdAt.toISOString(),
-    })),
+    items: items.map((r) => {
+      const parsed = parseLeadContext(r.message);
+
+      return {
+        id: r.id,
+        first_name: r.firstName,
+        last_name: r.lastName,
+        email: r.email,
+        message: parsed.cleanMessage,
+        raw_message: r.message,
+        lead_context: parsed.leadContext,
+        status: r.status,
+        source_ip: r.sourceIp,
+        created_at: r.createdAt.toISOString(),
+      };
+    }),
   });
 }
 


### PR DESCRIPTION
## Summary
- Parses Start Smart lead metadata from enriched contact messages in the admin contacts API.
- Returns structured `lead_context`, `raw_message`, and cleaned `message` fields from `/api/admin/contacts`.
- Adds lead-intent filtering for Course, CCW workshop, Equipment/service, and Team/buyer enquiries.
- Surfaces Start Smart lead context in the admin contact inbox as readable chips/cards instead of burying it in message text.

## Verification
- `npm run type-check`
- `npm run lint` passed with existing warnings only
- `npm run build` passed with existing project warnings only

## Notes
- Admin contacts is auth-gated, so browser verification was not run against a live admin session in this branch.
- Existing warnings remain: deprecated middleware convention, admin-catalog Turbopack trace warning, missing `GOOGLE_GENERATIVE_AI_API_KEY`, Edge runtime static-generation note, and existing lint warnings.
- Left pre-existing untracked `.autogit.json` and `.claude/` untouched.
