### PR TITLE
Roadshow page: readable contrast, correct name (Phill McGurk), CARSI brand colours

### DIFF
--- a/app/(public)/events/ccw-roadshow/page.tsx
+++ b/app/(public)/events/ccw-roadshow/page.tsx
@@ -10,7 +10,7 @@ import {
   marketingBody,
   marketingBodySm,
   marketingBtnSecondary,
-  marketingEyebrowEmerald,
+  marketingEyebrowAmber,
   marketingEyebrowPill,
   marketingHeading,
   marketingPageGlow,
@@ -137,22 +137,22 @@ export default function CcwRoadshowPage() {
           <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(300px,420px)] lg:items-start lg:gap-12">
             <div className="min-w-0">
               <span
-                className={`inline-flex items-center gap-2 rounded-full border border-[#34d399]/25 bg-[#34d399]/10 px-3 py-1 text-xs font-medium text-[#34d399]`}
+                className={`inline-flex items-center gap-2 rounded-full border border-[#ed9d24]/25 bg-[#ed9d24]/10 px-3 py-1 text-xs font-medium text-[#ed9d24]`}
               >
                 <span className="relative flex h-2 w-2">
-                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[#34d399] opacity-40" />
-                  <span className="relative inline-flex h-2 w-2 rounded-full bg-[#34d399]" />
+                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[#ed9d24] opacity-40" />
+                  <span className="relative inline-flex h-2 w-2 rounded-full bg-[#ed9d24]" />
                 </span>
                 Melbourne + Sydney · July 2026
               </span>
 
-              <p className={`mt-5 ${marketingEyebrowEmerald}`}>
+              <p className={`mt-5 ${marketingEyebrowAmber}`}>
                 CARSI and Carpet Cleaners Warehouse
               </p>
 
               <h1 className={`mt-3 ${marketingHeading}`}>{ccwRoadshowHeroHeadline}</h1>
 
-              <p className="mt-3 text-lg font-semibold text-[#34d399]">
+              <p className="mt-3 text-lg font-semibold text-[#ed9d24]">
                 Spend two days with {ccwRoadshowPresenter.name}
               </p>
 
@@ -169,7 +169,7 @@ export default function CcwRoadshowPage() {
                   <p className={`mt-1 ${marketingBodySm}`}>Melbourne 22-23, Sydney 30-31</p>
                 </div>
                 <div className={marketingStatCard}>
-                  <Users className="mb-3 h-4 w-4 text-[#34d399]/80" aria-hidden />
+                  <Users className="mb-3 h-4 w-4 text-[#ed9d24]/80" aria-hidden />
                   <p className="text-sm font-semibold text-white/90">Free CCW entry</p>
                   <p className={`mt-1 ${marketingBodySm}`}>Past/current customers claim a token</p>
                 </div>

--- a/app/(public)/events/ccw-roadshow/page.tsx
+++ b/app/(public)/events/ccw-roadshow/page.tsx
@@ -125,7 +125,11 @@ export default function CcwRoadshowPage() {
         />
       ))}
 
-      <main className="relative min-h-screen pb-16 pt-6 text-white sm:pb-20 sm:pt-8">
+      <main
+        id="main-content"
+        className="relative min-h-screen pb-16 pt-6 text-white sm:pb-20 sm:pt-8"
+        style={{ background: '#060a14' }}
+      >
         <div className={marketingPageGlow} aria-hidden="true" />
 
         {/* Hero */}
@@ -266,7 +270,7 @@ export default function CcwRoadshowPage() {
                   {pillar.points.map((point) => (
                     <div key={point} className="flex gap-3">
                       <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[#2490ed]" />
-                      <p className={`${marketingBodySm} text-white/50`}>{point}</p>
+                      <p className={marketingBodySm}>{point}</p>
                     </div>
                   ))}
                 </div>

--- a/app/(public)/events/ccw-roadshow/page.tsx
+++ b/app/(public)/events/ccw-roadshow/page.tsx
@@ -40,7 +40,7 @@ const canonical = `${siteUrl}${ccwRoadshowPath}`;
 export const metadata: Metadata = {
   title: 'Grow Your Cleaning Business | CARSI x CCW Roadshow 2026',
   description:
-    'Free for CCW past and current customers. Spend two practical days with Phil McGurk at CCW Melbourne or Sydney and claim a free entry token when you register.',
+    'Free for CCW past and current customers. Spend two practical days with Phill McGurk at CCW Melbourne or Sydney and claim a free entry token when you register.',
   alternates: { canonical },
   keywords: [
     'carpet cleaning training Melbourne',
@@ -54,7 +54,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'Grow Your Cleaning Business with CARSI x CCW',
     description:
-      'Two practical business-growth days with Phil McGurk inside CCW Melbourne and Sydney locations.',
+      'Two practical business-growth days with Phill McGurk inside CCW Melbourne and Sydney locations.',
     url: canonical,
     type: 'website',
     images: ['/og-image.png'],
@@ -255,7 +255,7 @@ export default function CcwRoadshowPage() {
           <MarketingSectionHeader
             eyebrow="Why, Who, What"
             title="Business improvement, not just a chemical day"
-            body="The value is not only the topic list. The value is spending two days with Phil, CARSI and the CCW team connecting services, equipment, chemicals and real customer decisions into a plan you can use."
+            body="The value is not only the topic list. The value is spending two days with Phill, CARSI and the CCW team connecting services, equipment, chemicals and real customer decisions into a plan you can use."
           />
 
           <div className="grid gap-4 lg:grid-cols-3">

--- a/docs/CONTENT_PARITY_AUDIT.md
+++ b/docs/CONTENT_PARITY_AUDIT.md
@@ -99,7 +99,7 @@ Admin Sole Trader ($275), AGI Essentials, Asthma and Allergy ($129), Carpet Clea
 | Partner images       | 2 partner images                                                                       | None                                           | GAP       |
 | Next.js pricing      | N/A                                                                                    | $795 AUD/year single tier with Stripe checkout | DIFFERENT |
 
-**Critical gap:** WordPress has 3 membership tiers (Free, $44/mo, $99/mo). Next.js has a single $795/year subscription. The tiered pricing structure is missing. This may be intentional (business model change), but should be confirmed with Phil.
+**Critical gap:** WordPress has 3 membership tiers (Free, $44/mo, $99/mo). Next.js has a single $795/year subscription. The tiered pricing structure is missing. This may be intentional (business model change), but should be confirmed with Phill.
 
 ### 5. Contact Page
 

--- a/docs/marketing/association-partnerships.md
+++ b/docs/marketing/association-partnerships.md
@@ -135,7 +135,7 @@ Establish CARSI as a recognised training partner across 7+ Australian industry a
 
 Dear [Name],
 
-I'm Phil from CARSI (carsi.com.au), an Australian-owned online training platform delivering IICRC CEC-approved courses in restoration, mould remediation and water damage management.
+I'm Phill from CARSI (carsi.com.au), an Australian-owned online training platform delivering IICRC CEC-approved courses in restoration, mould remediation and water damage management.
 
 We'd like to explore a training partnership with [Association Name] — offering your members discounted access to 40+ IICRC-approved courses, all available online and self-paced.
 
@@ -144,7 +144,7 @@ There's no cost to the association. Members receive a discount code and verifiab
 Would you be open to a 15-minute call to discuss?
 
 Kind regards,
-Phil
+Phill
 CARSI — Restoration Courses & Training Online
 carsi.com.au | training@carsi.com.au
 
@@ -178,7 +178,7 @@ This arrangement has worked well with other industry bodies and we'd welcome the
 Would you be available for a brief call next week?
 
 Kind regards,
-Phil
+Phill
 CARSI — Restoration Courses & Training Online
 carsi.com.au | training@carsi.com.au
 
@@ -192,7 +192,7 @@ carsi.com.au | training@carsi.com.au
 
 Dear [Name],
 
-I'm Phil from CARSI (carsi.com.au) — an Australian-owned online training platform specialising in IICRC CEC-approved courses for restoration, cleaning and building maintenance professionals.
+I'm Phill from CARSI (carsi.com.au) — an Australian-owned online training platform specialising in IICRC CEC-approved courses for restoration, cleaning and building maintenance professionals.
 
 I'm reaching out because I believe [Association Name] members could significantly benefit from access to our training catalogue, and I'd like to explore a formal partnership.
 
@@ -224,7 +224,7 @@ If the partnership delivers value, we're open to upgrading to **Preferred Traini
 I've attached a one-page partnership overview. Would you be open to a 15-minute introductory call? I'm happy to work around your availability.
 
 Kind regards,
-Phil
+Phill
 CARSI — Restoration Courses & Training Online
 carsi.com.au | training@carsi.com.au
 
@@ -269,7 +269,7 @@ CARSI (carsi.com.au) is an Australian-owned online training platform delivering 
 - Digital-first: verifiable credentials, LinkedIn sharing, employer audit trail
 
 **Next Step**
-15-minute introductory call with Phil → pilot with 3 member organisations → formal endorsement.
+15-minute introductory call with Phill → pilot with 3 member organisations → formal endorsement.
 
 Contact: training@carsi.com.au | carsi.com.au
 

--- a/docs/marketing/ccw-roadshow-approval-pack.md
+++ b/docs/marketing/ccw-roadshow-approval-pack.md
@@ -36,7 +36,7 @@ Generators:
 
 - Phill approved the original visual proof set in chat on 17 June 2026; 18 June free-entry copy has now been applied to the proof set.
 - CCW confirms venue details, addresses, free-entry eligibility, seat capacity, brand use and facility wording.
-- Phil approves name prominence, role line and any image/bio before a headshot or expanded presenter copy is used.
+- Phill approves name prominence, role line and any image/bio before a headshot or expanded presenter copy is used.
 - CARSI confirms course outline, chemical-detail wording, free-entry token terms and non-RTO boundary.
 - CCW confirms email-list consent basis, suppression list, unsubscribe URL, sender profile and audience segments.
 - Synthex confirms final UTM links, publish dates/times, platform owners and rollback owner.
@@ -51,7 +51,7 @@ Generators:
 
 ## Known Open Inputs
 
-- Approved Phil headshot and short bio.
+- Approved Phill headshot and short bio.
 - CCW facility photos for Melbourne and Sydney.
 - Confirmed seat capacity for each location.
 - Final unsubscribe URL and sender postal/address footer for the CCW client-list email.

--- a/docs/marketing/ccw-roadshow-campaign.md
+++ b/docs/marketing/ccw-roadshow-campaign.md
@@ -22,12 +22,12 @@ This is not a generic seminar or a simple chemical information day. It is a hand
 
 Core message:
 
-> Spend two days with Phil McGurk inside Carpet Cleaners Warehouse and leave with clearer strategies to pursue better-fit jobs, quote with confidence, avoid costly mistakes, add profitable services and build a stronger cleaning business.
+> Spend two days with Phill McGurk inside Carpet Cleaners Warehouse and leave with clearer strategies to pursue better-fit jobs, quote with confidence, avoid costly mistakes, add profitable services and build a stronger cleaning business.
 
 Message hierarchy:
 
 1. Dominant headline: `Grow Your Cleaning Business`.
-2. Credibility line: `Spend two days with Phil McGurk`.
+2. Credibility line: `Spend two days with Phill McGurk`.
 3. Event name: `CARSI x CCW Business Growth Days`.
 4. Outcome proof: better-fit jobs, profit decisions, fewer mistakes, profitable service planning, quoting confidence and stronger systems.
 5. Urgency: free past/current CCW customer entry, limited places, small group format, register early.
@@ -38,7 +38,7 @@ Toby's 17 June review notes reposition the campaign away from a subject list and
 
 - Whyte-style competitor events communicate quickly because they answer "why attend?" in seconds. CARSI x CCW must do the same.
 - The stronger offer is not "a chemical day"; it is business growth, better decision making and practical industry experience.
-- Phil McGurk's name should be visible because his reputation is a major drawcard for cleaners.
+- Phill McGurk's name should be visible because his reputation is a major drawcard for cleaners.
 - The CCW facility setting matters: attendees can see equipment, compare options, ask practical questions and connect training to real-world applications.
 - Replace passive "Books are essential" as the main urgency line with stronger action cues such as "Limited places available", "Small group format" and "Register early".
 - Add approved social proof where available. Do not invent testimonials; use a placeholder only until a real attendee quote is approved.
@@ -103,7 +103,7 @@ Marketing angle:
 
 Why this exists:
 
-> Cleaning businesses grow when training, equipment, chemicals and service offers work together. CARSI and CCW are bringing that conversation into one room in Melbourne and Sydney this July with Phil McGurk leading practical business-improvement sessions inside CCW facilities.
+> Cleaning businesses grow when training, equipment, chemicals and service offers work together. CARSI and CCW are bringing that conversation into one room in Melbourne and Sydney this July with Phill McGurk leading practical business-improvement sessions inside CCW facilities.
 
 ### Interest Message
 
@@ -176,7 +176,7 @@ Why register now:
 
 Grow your cleaning business.
 
-CARSI x Carpet Cleaners Warehouse Business Growth Days are coming to Melbourne and Sydney, with two practical days led by Phil McGurk inside CCW facilities.
+CARSI x Carpet Cleaners Warehouse Business Growth Days are coming to Melbourne and Sydney, with two practical days led by Phill McGurk inside CCW facilities.
 
 Why? Because growth needs more than another machine or product. Training, equipment, chemicals, service offers, quoting and follow-up all need to work together.
 
@@ -200,7 +200,7 @@ Grow your cleaning business with CARSI and CCW.
 
 We are hosting CARSI x CCW Business Growth Days at our Melbourne and Sydney locations this July.
 
-These are practical two-day sessions with Phil McGurk for operators who want stronger carpet cleaning, rug cleaning, stain removal, tile cleaning and business growth confidence.
+These are practical two-day sessions with Phill McGurk for operators who want stronger carpet cleaning, rug cleaning, stain removal, tile cleaning and business growth confidence.
 
 Why come? To connect training, equipment, chemicals and service decisions before you spend more money or take on harder work.
 
@@ -224,7 +224,7 @@ Small group format. Limited places available. Claim your free token here: https:
 
 For anyone in Melbourne or Sydney who wants to grow a cleaning business, CARSI and CCW are running two-day Business Growth Days in July.
 
-The focus is practical: spend two days with Phil McGurk inside Carpet Cleaners Warehouse and connect training, equipment, chemistry and service decisions before you sell the work or spend more money.
+The focus is practical: spend two days with Phill McGurk inside Carpet Cleaners Warehouse and connect training, equipment, chemistry and service decisions before you sell the work or spend more money.
 
 Why: to get clearer before adding services, buying equipment or quoting more complex jobs.
 
@@ -243,13 +243,13 @@ Registration link: https://www.carsi.com.au/events/ccw-roadshow
 
 ### Email 1: Why Attend
 
-Subject: Spend two days with Phil McGurk
+Subject: Spend two days with Phill McGurk
 
 Body:
 
 CARSI and Carpet Cleaners Warehouse are bringing two-day Business Growth Days to Melbourne and Sydney this July because cleaning businesses need more than isolated tips, products or machine advice.
 
-Spend two practical days with Phil McGurk inside Carpet Cleaners Warehouse and connect training, equipment, chemicals, service offers, quoting and customer follow-up before buying more gear, adding more services or taking on harder jobs.
+Spend two practical days with Phill McGurk inside Carpet Cleaners Warehouse and connect training, equipment, chemicals, service offers, quoting and customer follow-up before buying more gear, adding more services or taking on harder jobs.
 
 Melbourne runs 22-23 July. Sydney runs 30-31 July. Both days run 8.30am-4.30pm.
 
@@ -302,7 +302,7 @@ Claim your team token here: https://www.carsi.com.au/events/ccw-roadshow
 - Visual priority: Why, Who, What they achieve, plus CARSI x CCW, city, dates, free past/current CCW customer entry, token CTA.
 - Avoid: overclaiming certification outcomes, "guaranteed income", or implying RTO/national qualification status.
 - Suggested headline: "Grow Your Cleaning Business"
-- Suggested subhead: "Spend two days with Phil McGurk inside Carpet Cleaners Warehouse."
+- Suggested subhead: "Spend two days with Phill McGurk inside Carpet Cleaners Warehouse."
 - Badge: "Past/current CCW customers free"
 - Urgency badge: "Claim your free entry token"
 - Proof slot: "Insert approved attendee quote here" only after a real quote is supplied.
@@ -313,7 +313,7 @@ Claim your team token here: https://www.carsi.com.au/events/ccw-roadshow
 
 Headline: Grow your cleaning business.
 
-Body: Spend two practical days with Phil McGurk connecting training, equipment, chemicals, services, quoting and follow-up before spending more money or taking on harder jobs.
+Body: Spend two practical days with Phill McGurk connecting training, equipment, chemicals, services, quoting and follow-up before spending more money or taking on harder jobs.
 
 CTA: Claim your free token.
 

--- a/docs/marketing/ccw-roadshow-email-social-pack.md
+++ b/docs/marketing/ccw-roadshow-email-social-pack.md
@@ -23,13 +23,13 @@ All emails need the live unsubscribe link, sender address, CCW/CARSI approval an
 
 Subject: Grow your cleaning business this July
 
-Preheader: Two practical days with Phil McGurk inside CCW Melbourne or Sydney.
+Preheader: Two practical days with Phill McGurk inside CCW Melbourne or Sydney.
 
 Body:
 
 CARSI and Carpet Cleaners Warehouse are bringing Business Growth Days to Melbourne and Sydney this July.
 
-Spend two practical days with Phil McGurk inside CCW and connect training, equipment, chemicals, service offers, quoting and customer follow-up before you spend more money or take on harder work.
+Spend two practical days with Phill McGurk inside CCW and connect training, equipment, chemicals, service offers, quoting and customer follow-up before you spend more money or take on harder work.
 
 Melbourne: 22-23 July at CCW Bayswater North.
 Sydney: 30-31 July at CCW Seven Hills.
@@ -91,7 +91,7 @@ CTA: Claim your free entry token before final seats close.
 2. Why: Training, equipment, chemicals, quoting and follow-up should work together before a business spends more money.
 3. Who: Built for carpet cleaners, cleaners adding services, rug and stain operators, tile cleaners, teams and new entrants.
 4. What: Leave with clearer strategies to pursue better-fit jobs, quote with confidence and avoid costly mistakes.
-5. Phil: Spend two days with Phil McGurk and the CCW team inside working CCW facilities.
+5. Phill: Spend two days with Phill McGurk and the CCW team inside working CCW facilities.
 6. Facility: This is not a hotel-room talk; attendees can see equipment, compare options and ask practical questions.
 7. Team entry: CCW past and current customers can claim free entry for up to five people and give the team one shared operating language.
 8. Course material: Course outline and practical chemical details are included.
@@ -101,7 +101,7 @@ CTA: Claim your free entry token before final seats close.
 ## CCW Social Posts
 
 1. We are hosting CARSI x CCW Business Growth Days at our Melbourne and Sydney locations.
-2. Spend two practical days with Phil McGurk inside Carpet Cleaners Warehouse.
+2. Spend two practical days with Phill McGurk inside Carpet Cleaners Warehouse.
 3. Connect equipment, chemicals, training and customer decisions before buying or quoting.
 4. Better questions before buying equipment can prevent expensive wrong turns.
 5. Practical chemical details and the course outline are included as part of the material.

--- a/docs/marketing/search-ai-growth-plan-carsi-ccw.md
+++ b/docs/marketing/search-ai-growth-plan-carsi-ccw.md
@@ -146,7 +146,7 @@ Implement and validate these in order:
 3. `Course` and `CourseInstance`/course list data for core CARSI courses.
 4. `Event` data for Melbourne and Sydney Roadshow pages, including free entry for eligible CCW customers where represented on-page.
 5. `FAQPage` or visible Q&A content on Start Smart and Roadshow pages.
-6. `ProfilePage`/`Person` for Toby, Phil, trainers, and recognised experts once bios are approved.
+6. `ProfilePage`/`Person` for Toby, Phill, trainers, and recognised experts once bios are approved.
 7. `Article`/`NewsArticle` for evidence library updates and Roadshow recap articles.
 8. `VideoObject` for any training clips, Roadshow previews, and YouTube embeds.
 

--- a/docs/marketing/synthex-ccw-roadshow-launch-packet.md
+++ b/docs/marketing/synthex-ccw-roadshow-launch-packet.md
@@ -7,7 +7,7 @@ Launch status: free-entry offer update applied. Organic publishing may proceed t
 
 Campaign name: CARSI x CCW Business Growth Days
 Dominant campaign headline: Grow Your Cleaning Business
-Credibility hook: Spend two days with Phil McGurk inside Carpet Cleaners Warehouse.
+Credibility hook: Spend two days with Phill McGurk inside Carpet Cleaners Warehouse.
 
 Primary registration URL:
 
@@ -38,7 +38,7 @@ Included material:
 Toby review inputs now integrated:
 
 - Lead with outcomes, not subject areas.
-- Make Phil McGurk visible as a major reason to attend.
+- Make Phill McGurk visible as a major reason to attend.
 - Position the event as business improvement, not only a chemical or product day.
 - Explain why being inside CCW facilities matters: see, compare, ask and connect training to real-world decisions.
 - Use stronger urgency language than "Books are essential".
@@ -102,7 +102,7 @@ Message:
 
 > Grow your cleaning business.
 >
-> CARSI x Carpet Cleaners Warehouse Business Growth Days are coming to Melbourne and Sydney this July. Spend two practical days with Phil McGurk inside CCW facilities, connecting carpet cleaning, rug cleaning, stain removal, tile cleaning, equipment, chemicals, course material, quoting confidence and business growth.
+> CARSI x Carpet Cleaners Warehouse Business Growth Days are coming to Melbourne and Sydney this July. Spend two practical days with Phill McGurk inside CCW facilities, connecting carpet cleaning, rug cleaning, stain removal, tile cleaning, equipment, chemicals, course material, quoting confidence and business growth.
 >
 > Melbourne: 22-23 July at CCW Bayswater North
 > Sydney: 30-31 July at CCW Seven Hills
@@ -118,7 +118,7 @@ Timing: 22 June to 5 July 2026.
 Angles:
 
 - Why training should come before buying more equipment.
-- Spend two days with Phil McGurk.
+- Spend two days with Phill McGurk.
 - Why this is a business improvement event, not just a chemical day.
 - Why CCW facilities make the learning more practical: see it, compare it, ask questions.
 - How chemical decisions shape customer outcomes.
@@ -148,12 +148,12 @@ Timing:
 
 Message:
 
-> Final reminder: CARSI x CCW Business Growth Days are nearly here. If you want to spend two practical days with Phil McGurk and leave with clearer strategies for services, equipment, chemicals, quoting, customer conversations and business growth, claim your free past/current CCW customer entry token now.
+> Final reminder: CARSI x CCW Business Growth Days are nearly here. If you want to spend two practical days with Phill McGurk and leave with clearer strategies for services, equipment, chemicals, quoting, customer conversations and business growth, claim your free past/current CCW customer entry token now.
 
 ## Daily Social Prompts
 
 1. Why this exists: growth happens when training, equipment, chemicals and service promises connect.
-2. Phil hook: spend two days learning directly from Phil McGurk.
+2. Phill hook: spend two days learning directly from Phill McGurk.
 3. CCW facility advantage: see equipment, compare options and ask practical questions.
 4. Who should attend: cleaners adding services, existing carpet cleaners, teams and new operators.
 5. What you receive: course outline and practical chemical details.

--- a/docs/plans/2026-03-03-carsi-lms-enhancements-design.md
+++ b/docs/plans/2026-03-03-carsi-lms-enhancements-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-03-03
 **Status:** Approved
-**Author:** Brainstorming session with Phil
+**Author:** Brainstorming session with Phill
 
 ---
 
@@ -50,7 +50,7 @@ CARSI is the only LMS in Australia that:
 - **OCT** — Odour Control Technician
 - **ASD** — Applied Structural Drying
 - **CCT** — Commercial Carpet Maintenance Technician
-- _(Additional disciplines to be confirmed with Phil)_
+- _(Additional disciplines to be confirmed with Phill)_
 
 **IICRC CECs** are Continuing Education Credits required to maintain IICRC certification. CARSI courses are CEC-accredited — meaning completing a CARSI course earns CECs toward IICRC recertification.
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/marketing/CcwRoadshowBooking.tsx
+++ b/src/components/marketing/CcwRoadshowBooking.tsx
@@ -32,7 +32,7 @@ type BookingFormState = {
   attendees: AttendeeForm[];
 };
 
-const labelClass = 'mb-1.5 block text-xs font-medium tracking-wide text-white/45 uppercase';
+const labelClass = 'mb-1.5 block text-xs font-medium tracking-wide text-white/70 uppercase';
 
 function emptyAttendee(): AttendeeForm {
   return { fullName: '', yearsExperience: '', goals: '' };

--- a/src/lib/marketing/ccw-roadshow.ts
+++ b/src/lib/marketing/ccw-roadshow.ts
@@ -40,10 +40,10 @@ export const ccwRoadshowFreeEntryOffer = {
 };
 
 export const ccwRoadshowPresenter = {
-  name: 'Phil McGurk',
+  name: 'Phill McGurk',
   role: 'CARSI founder and cleaning and restoration educator',
   value:
-    'Spend two practical days learning directly from Phil McGurk and the CCW team, with the conversation tied back to real equipment, chemicals, service decisions and customer outcomes.',
+    'Spend two practical days learning directly from Phill McGurk and the CCW team, with the conversation tied back to real equipment, chemicals, service decisions and customer outcomes.',
 };
 
 export const ccwRoadshowTopics = [
@@ -78,7 +78,7 @@ export const ccwRoadshowEvents: CcwRoadshowEvent[] = [
     suburbStatePostcode: 'Bayswater North VIC 3153',
     state: 'VIC',
     description:
-      'Two practical days with Phil McGurk and the CCW team, connecting training, equipment, service design, chemistry, quoting confidence and business growth for carpet, rug, stain and tile cleaning operators.',
+      'Two practical days with Phill McGurk and the CCW team, connecting training, equipment, service design, chemistry, quoting confidence and business growth for carpet, rug, stain and tile cleaning operators.',
     capacity: 10,
     calendarEventId: '1d1uqjm6an36n1kgc6s4s3ln7s',
   },
@@ -97,7 +97,7 @@ export const ccwRoadshowEvents: CcwRoadshowEvent[] = [
     suburbStatePostcode: 'Seven Hills NSW 2147',
     state: 'NSW',
     description:
-      'Two practical days with Phil McGurk and the CCW team, connecting training, equipment, service design, chemistry, quoting confidence and business growth for carpet, rug, stain and tile cleaning operators.',
+      'Two practical days with Phill McGurk and the CCW team, connecting training, equipment, service design, chemistry, quoting confidence and business growth for carpet, rug, stain and tile cleaning operators.',
     capacity: 12,
     calendarEventId: 'h6qm8t3muuv44ht9gqann5dhuk',
   },

--- a/src/lib/marketing/marketing-ui.ts
+++ b/src/lib/marketing/marketing-ui.ts
@@ -35,9 +35,9 @@ export const marketingInput =
 export const marketingPageGlow =
   'pointer-events-none fixed inset-0 z-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_0%,rgba(36,144,237,0.07),transparent_55%)]';
 
-export const marketingBody = 'text-base leading-relaxed text-white/55 sm:text-lg';
+export const marketingBody = 'text-base leading-relaxed text-white/75 sm:text-lg';
 
-export const marketingBodySm = 'text-sm leading-relaxed text-white/45';
+export const marketingBodySm = 'text-sm leading-relaxed text-white/65';
 
 export const marketingHeading =
   'text-4xl leading-[1.08] font-bold tracking-tight text-balance text-white sm:text-5xl lg:text-[3.25rem] lg:leading-[1.06]';
@@ -49,4 +49,4 @@ export const marketingStatCard =
   'rounded-2xl border border-white/[0.08] bg-gradient-to-b from-white/[0.07] to-white/[0.02] px-4 py-5 shadow-[0_16px_48px_-28px_rgba(0,0,0,0.8)]';
 
 export const marketingTopicPill =
-  'rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-xs text-white/55';
+  'rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-xs text-white/75';


### PR DESCRIPTION
Visual-only fixes to the public CCW roadshow event page. No DB/logic changes — renders correctly with or without the registry migration.

- **Contrast**: the page used dark-theme content but no background, so white text rendered on the light public layout (near-invisible + a11y contrast failure). Adds the dark `#060a14` background (matching sibling marketing pages), the missing `id="main-content"` skip-link target, and lifts dimmed text/labels to WCAG-AA (`white/45–55` → `white/65–75`).
- **Name**: corrected "Phil McGurk" → **Phill McGurk** across the page and all marketing docs.
- **Brand**: replaced off-brand emerald green (`#34d399`) accents with CARSI brand amber (`#ed9d24`), keeping the on-brand primary blue + dark navy.

Verified in local preview (screenshots in the session): dark, readable, amber+blue, correct name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)