### PR TITLE
Payments: team-purchase idempotency — drop the shared webhook reference literal

### DIFF
--- a/app/api/lms/webhooks/stripe/route.ts
+++ b/app/api/lms/webhooks/stripe/route.ts
@@ -17,6 +17,7 @@ import { sessionClaimsForUserId } from '@/lib/server/lms-auth';
 import { prisma } from '@/lib/prisma';
 import { fulfillCourseCheckoutForUser } from '@/lib/server/team-course-purchase';
 import { shouldRetryWebhookFulfillment } from '@/lib/server/stripe-webhook-policy';
+import { resolveStripePaymentReference } from '@/lib/server/stripe-payment-reference';
 
 export async function POST(request: NextRequest) {
   const rawBody = await request.text();
@@ -93,8 +94,15 @@ export async function POST(request: NextRequest) {
   const teamSeatRaw = session.metadata?.team_seat_count;
   const teamSeatCount = teamSeatRaw ? Number.parseInt(teamSeatRaw, 10) : undefined;
 
+  const ref = resolveStripePaymentReference(session.id);
+  if (!ref) {
+    console.error(
+      '[stripe webhook] checkout.session.completed missing a session id — skipping fulfillment to avoid non-idempotent provisioning',
+    );
+    return NextResponse.json({ received: true });
+  }
+
   try {
-    const ref = typeof session.id === 'string' ? session.id : 'stripe_webhook';
     const origin = getAppOrigin();
     const fulfilled = await fulfillCourseCheckoutForUser({
       claims,

--- a/src/lib/server/stripe-payment-reference.test.ts
+++ b/src/lib/server/stripe-payment-reference.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveStripePaymentReference } from './stripe-payment-reference';
+
+describe('resolveStripePaymentReference', () => {
+  it('returns the trimmed Stripe session id', () => {
+    expect(resolveStripePaymentReference('cs_test_123')).toBe('cs_test_123');
+    expect(resolveStripePaymentReference('  cs_test_123  ')).toBe('cs_test_123');
+  });
+
+  it('returns null for a missing / blank / non-string id (never a shared literal)', () => {
+    expect(resolveStripePaymentReference('')).toBeNull();
+    expect(resolveStripePaymentReference('   ')).toBeNull();
+    expect(resolveStripePaymentReference(undefined)).toBeNull();
+    expect(resolveStripePaymentReference(null)).toBeNull();
+    expect(resolveStripePaymentReference(123)).toBeNull();
+  });
+});

--- a/src/lib/server/stripe-payment-reference.ts
+++ b/src/lib/server/stripe-payment-reference.ts
@@ -1,0 +1,14 @@
+/**
+ * Resolves the idempotency key for a Stripe checkout fulfillment from the
+ * session id. Returns the trimmed id, or null when it is missing/blank.
+ *
+ * Pure (no imports). Crucially it NEVER returns a shared literal fallback — a
+ * shared key (the old "stripe_webhook") collapses unrelated purchases into one
+ * idempotency bucket, which breaks de-duplication. A null result means
+ * "no reliable key", so callers should skip rather than provision.
+ */
+export function resolveStripePaymentReference(sessionId: unknown): string | null {
+  if (typeof sessionId !== 'string') return null;
+  const trimmed = sessionId.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/src/lib/server/team-course-purchase.ts
+++ b/src/lib/server/team-course-purchase.ts
@@ -55,6 +55,10 @@ async function insertTeamCoursePurchaseTx(
       where: { paymentReference: ref },
     });
     if (existing) return false;
+  } else {
+    console.warn(
+      '[team-purchase] provisioning a team seat block without a payment reference — duplicate deliveries cannot be de-duplicated for this row',
+    );
   }
 
   await tx.lmsTeamCoursePurchase.create({


### PR DESCRIPTION
Completes the deferred **C2** from the QA audit (now unblocked — #170's webhook change is already on main).

**Problem:** the Stripe webhook fell back to a literal `"stripe_webhook"` payment reference when a session id was absent, collapsing unrelated purchases into one idempotency bucket — so a team seat block could be double-provisioned.

**Fix:**
- New unit-tested `resolveStripePaymentReference()` returns the real (trimmed) Stripe session id, or `null` — **never a shared literal**.
- The webhook now **skips fulfillment with a log** when there is no reliable key, instead of provisioning under a collision-prone reference.
- `insertTeamCoursePurchaseTx` **warns** instead of silently skipping de-dup when no reference is present.

**Deferred (noted in commit):** a partial unique index on `lms_team_course_purchases(payment_reference)` for the theoretical concurrent-retry race — it needs a careful dedup-then-index migration on prod, so it's left for the migration pass. Stripe retries aren't concurrent, so the app-layer de-dup covers the realistic case.

Verified: 44 unit tests pass, `tsc` clean, `next build` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)