### PR TITLE
Roadshow: graceful registration fallback until the registry migration runs

### DIFF
--- a/app/api/events/ccw-roadshow/checkout/route.ts
+++ b/app/api/events/ccw-roadshow/checkout/route.ts
@@ -15,6 +15,7 @@ import {
   type AttendeeInput,
 } from '@/lib/server/ccw-roadshow-registry';
 import { addRegistrationToCalendar } from '@/lib/server/ccw-roadshow-calendar';
+import { isMissingTableError } from '@/lib/server/db-errors';
 import { sendCcwRoadshowRegistrationEmail } from '@/lib/server/transactional-email';
 
 type AttendeeBody = { fullName?: string; yearsExperience?: string; goals?: string };
@@ -95,22 +96,43 @@ export async function POST(request: NextRequest) {
 
     const freeEntryToken = generateFreeEntryToken(event.slug);
 
-    const result = await createRoadshowRegistration({
-      event,
-      companyName,
-      contactEmail,
-      contactPhone,
-      ccwCustomerStatus,
-      attendees,
-      freeEntryToken,
-    });
+    let result;
+    try {
+      result = await createRoadshowRegistration({
+        event,
+        companyName,
+        contactEmail,
+        contactPhone,
+        ccwCustomerStatus,
+        attendees,
+        freeEntryToken,
+      });
+    } catch (error) {
+      if (isMissingTableError(error)) {
+        // Registry tables not migrated yet — degrade gracefully: still issue a
+        // token (and fire CRM + email below) so registration works, just
+        // without persistence/caps. Full caps/waitlist resume once
+        // `prisma migrate deploy` has run.
+        console.warn(
+          '[ccw-roadshow] registry tables missing — issued a token without persistence/caps. Run prisma migrate deploy.',
+        );
+        result = {
+          registrationId: '',
+          status: 'confirmed' as const,
+          seatCount: attendees.length,
+          remaining: event.capacity,
+        };
+      } else {
+        throw error;
+      }
+    }
 
     if (result.status === 'confirmed') {
       const synced = await addRegistrationToCalendar({
         calendarEventId: event.calendarEventId,
         attendeeEmail: contactEmail,
       });
-      if (synced) {
+      if (synced && result.registrationId) {
         await setRegistrationCalendarSynced(result.registrationId);
       }
     }

--- a/src/lib/server/db-errors.test.ts
+++ b/src/lib/server/db-errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isUniqueConstraintError } from './db-errors';
+import { isMissingTableError, isUniqueConstraintError } from './db-errors';
 
 describe('isUniqueConstraintError', () => {
   it('detects the Prisma P2002 unique-constraint code', () => {
@@ -12,5 +12,17 @@ describe('isUniqueConstraintError', () => {
     expect(isUniqueConstraintError(new Error('boom'))).toBe(false);
     expect(isUniqueConstraintError(undefined)).toBe(false);
     expect(isUniqueConstraintError(null)).toBe(false);
+  });
+});
+
+describe('isMissingTableError', () => {
+  it('detects the Prisma P2021 "table does not exist" code', () => {
+    expect(isMissingTableError({ code: 'P2021' })).toBe(true);
+  });
+
+  it('returns false for other codes and unrelated errors', () => {
+    expect(isMissingTableError({ code: 'P2002' })).toBe(false);
+    expect(isMissingTableError(new Error('boom'))).toBe(false);
+    expect(isMissingTableError(null)).toBe(false);
   });
 });

--- a/src/lib/server/db-errors.ts
+++ b/src/lib/server/db-errors.ts
@@ -10,3 +10,17 @@ export function isUniqueConstraintError(error: unknown): boolean {
     (error as { code?: unknown }).code === 'P2002'
   );
 }
+
+/**
+ * Detects a Prisma P2021 "table does not exist" error — i.e. a pending
+ * migration hasn't been applied yet. Lets callers degrade gracefully instead
+ * of 500ing until `prisma migrate deploy` runs.
+ */
+export function isMissingTableError(error: unknown): boolean {
+  return (
+    error !== null &&
+    typeof error === 'object' &&
+    'code' in error &&
+    (error as { code?: unknown }).code === 'P2021'
+  );
+}


### PR DESCRIPTION
Makes the live roadshow form usable before `prisma migrate deploy` has run. If the registry tables are missing (Prisma P2021), the checkout route issues a token + fires CRM/email instead of 500ing; full caps/waitlist/registry resume automatically once migrated. Unit-tested `isMissingTableError`; 46 tests pass, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)