### PR TITLE
Roadshow admin: delete a registration

### DIFF
--- a/app/api/admin/ccw-roadshow/route.ts
+++ b/app/api/admin/ccw-roadshow/route.ts
@@ -3,12 +3,34 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAdminSessionOrNull } from '@/lib/admin/admin-session';
 import { ccwRoadshowEvents } from '@/lib/marketing/ccw-roadshow';
 import {
+  deleteRoadshowRegistration,
   getRoadshowAvailability,
   listRoadshowRegistry,
 } from '@/lib/server/ccw-roadshow-registry';
 import { registryToCsv } from '@/lib/server/ccw-roadshow-csv';
 
 export const dynamic = 'force-dynamic';
+
+export async function DELETE(request: NextRequest) {
+  const session = await getAdminSessionOrNull();
+  if (!session) {
+    return NextResponse.json({ detail: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = (await request.json().catch(() => ({}))) as { registrationId?: string };
+  const registrationId = body.registrationId?.trim();
+  if (!registrationId) {
+    return NextResponse.json({ detail: 'registrationId is required.' }, { status: 400 });
+  }
+
+  try {
+    await deleteRoadshowRegistration(registrationId);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('[admin/ccw-roadshow] delete failed:', error);
+    return NextResponse.json({ detail: 'Failed to delete registration.' }, { status: 500 });
+  }
+}
 
 export async function GET(request: NextRequest) {
   const session = await getAdminSessionOrNull();

--- a/src/components/admin/AdminCcwRoadshowClient.tsx
+++ b/src/components/admin/AdminCcwRoadshowClient.tsx
@@ -65,6 +65,23 @@ export function AdminCcwRoadshowClient() {
     await load();
   }
 
+  async function remove(row: RegistryRow) {
+    if (!window.confirm(`Delete this registration (${row.contactEmail})? This frees its seats.`)) {
+      return;
+    }
+    const res = await fetch('/api/admin/ccw-roadshow', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ registrationId: row.registrationId }),
+    });
+    if (!res.ok) {
+      const payload = (await res.json().catch(() => ({}))) as { detail?: string };
+      setError(payload.detail || 'Failed to delete');
+      return;
+    }
+    await load();
+  }
+
   if (loading) return <div className="p-6">Loading registry…</div>;
 
   return (
@@ -129,15 +146,24 @@ export function AdminCcwRoadshowClient() {
                 </td>
                 <td className="p-2 font-mono text-xs">{row.freeEntryToken}</td>
                 <td className="p-2">
-                  {row.status === 'waitlisted' && (
+                  <div className="flex gap-2">
+                    {row.status === 'waitlisted' && (
+                      <button
+                        type="button"
+                        onClick={() => promote(row)}
+                        className="rounded-lg border px-2 py-1 text-xs font-medium"
+                      >
+                        Promote
+                      </button>
+                    )}
                     <button
                       type="button"
-                      onClick={() => promote(row)}
-                      className="rounded-lg border px-2 py-1 text-xs font-medium"
+                      onClick={() => remove(row)}
+                      className="rounded-lg border border-red-300 px-2 py-1 text-xs font-medium text-red-700"
                     >
-                      Promote
+                      Delete
                     </button>
-                  )}
+                  </div>
                 </td>
               </tr>
             ))}

--- a/src/lib/server/ccw-roadshow-registry.ts
+++ b/src/lib/server/ccw-roadshow-registry.ts
@@ -195,3 +195,8 @@ export async function setRegistrationCalendarSynced(registrationId: string): Pro
     data: { calendarSynced: true },
   });
 }
+
+/** Remove a registration (and its attendees, via cascade). Frees its seats. */
+export async function deleteRoadshowRegistration(registrationId: string): Promise<void> {
+  await prisma.ccwRoadshowRegistration.delete({ where: { id: registrationId } });
+}


### PR DESCRIPTION
Admin-gated DELETE on /api/admin/ccw-roadshow + a Delete button in the registry, so admins can remove test/spam/duplicate registrations (frees their seats). tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)